### PR TITLE
Fix `DeliveryMethod.email` casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ authentication methods. For example, let's use OTP via email:
 
 ```dart
 // sends an OTP code to the given email address
-await Descope.otp.signUp(method: DeliveryMethod.Email, loginId: 'andy@example.com');
+await Descope.otp.signUp(method: DeliveryMethod.email, loginId: 'andy@example.com');
 ```
 
 Finish the authentication by verifying the OTP code the user entered:
 
 ```dart
 // if the user entered the right code the authentication is successful
-final authResponse = await Descope.otp.verify(method: DeliveryMethod.Email, loginId: 'andy@example.com', code: code);
+final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: 'andy@example.com', code: code);
 
 // we create a DescopeSession object that represents an authenticated user session
 final session = DescopeSession.fromAuthenticationResponse(authResponse);

--- a/lib/descope.dart
+++ b/lib/descope.dart
@@ -11,9 +11,11 @@ import '/src/session/session.dart';
 export '/src/sdk/config.dart' show DescopeConfig;
 export '/src/sdk/routes.dart';
 export '/src/sdk/sdk.dart' show DescopeSdk;
-export '/src/session/lifecycle.dart' show DescopeSessionLifecycle, SessionLifecycle;
+export '/src/session/lifecycle.dart'
+    show DescopeSessionLifecycle, SessionLifecycle;
 export '/src/session/session.dart' show DescopeSession;
-export '/src/session/storage.dart' show DescopeSessionStorage, SessionStorage, SessionStorageStore;
+export '/src/session/storage.dart'
+    show DescopeSessionStorage, SessionStorage, SessionStorageStore;
 export '/src/session/token.dart' show DescopeToken;
 export '/src/types/others.dart';
 export '/src/types/responses.dart';
@@ -62,7 +64,7 @@ class Descope {
   /// You can use this [DescopeSessionManager] object as a shared instance to manage
   /// authenticated sessions in your application.
   ///
-  ///     final authResponse = Descope.otp.verify(DeliveryMethod.Email, 'andy@example.com', '123456')
+  ///     final authResponse = Descope.otp.verify(DeliveryMethod.email, 'andy@example.com', '123456')
   ///     val session = DescopeSession(authResponse)
   ///     Descope.sessionManager.manageSession(session)
   ///

--- a/lib/src/session/session.dart
+++ b/lib/src/session/session.dart
@@ -8,7 +8,7 @@ import 'token.dart';
 /// a `DescopeSession` object from the [AuthenticationResponse] value returned
 /// by all the authentication APIs.
 ///
-///     final authResponse = await Descope.otp.verify(method: DeliveryMethod.Email, loginId: 'andy@example.com', code: '123456');
+///     final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: 'andy@example.com', code: '123456');
 ///     final session = DescopeSession.fromAuthenticationResponse(authResponse);
 ///
 /// The session can then be used to authenticate outgoing requests to your backend
@@ -39,7 +39,10 @@ class DescopeSession {
   ///
   /// Use this initializer to create a [DescopeSession] after the user completes
   /// a sign in or sign up flow in the application.
-  DescopeSession.fromAuthenticationResponse(AuthenticationResponse authenticationResponse) : this(authenticationResponse.sessionToken, authenticationResponse.refreshToken, authenticationResponse.user);
+  DescopeSession.fromAuthenticationResponse(
+      AuthenticationResponse authenticationResponse)
+      : this(authenticationResponse.sessionToken,
+            authenticationResponse.refreshToken, authenticationResponse.user);
 
   /// Creates a new [DescopeSession] object from two JWT strings.
   ///
@@ -76,11 +79,13 @@ class DescopeSession {
 
   /// Returns the list of permissions granted for the user. Pass `null` for
   /// the [tenant] parameter if the user isn't associated with any tenant.
-  List<String> permissions([String? tenant]) => _sessionToken.getPermissions(tenant: tenant);
+  List<String> permissions([String? tenant]) =>
+      _sessionToken.getPermissions(tenant: tenant);
 
   /// Returns the list of roles for the user. Pass `null` for the [tenant]
   /// parameter if the user isn't associated with any tenant.
-  List<String> roles([String? tenant]) => _sessionToken.getRoles(tenant: tenant);
+  List<String> roles([String? tenant]) =>
+      _sessionToken.getRoles(tenant: tenant);
 
   // Updating the session manually when not using a DescopeSessionManager
 
@@ -118,7 +123,10 @@ class DescopeSession {
     if (identical(this, other)) {
       return true;
     }
-    return other is DescopeSession && other.sessionJwt == sessionJwt && other.refreshJwt == refreshJwt && other.user == user;
+    return other is DescopeSession &&
+        other.sessionJwt == sessionJwt &&
+        other.refreshJwt == refreshJwt &&
+        other.user == user;
   }
 
   @override

--- a/lib/src/types/user.dart
+++ b/lib/src/types/user.dart
@@ -15,7 +15,7 @@ part 'user.g.dart';
 /// code. The authentication response has a [DescopeUser] property which can be used
 /// directly or later on when it's kept in the [DescopeSession].
 ///
-///     final authResponse = await Descope.otp.verify(method: DeliveryMethod.Email, loginId: 'andy@example.com', code: '123456');
+///     final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: 'andy@example.com', code: '123456');
 ///     print('Finished OTP login for user: ${authResponse.user}');
 ///
 ///     Descope.sessionManager.session = DescopeSession(authResponse);
@@ -75,7 +75,16 @@ class DescopeUser {
   /// for this user. If `phone` is `null` then this is always `false`.
   final bool isVerifiedPhone;
 
-  DescopeUser(this.userId, this.loginIds, this.createdAt, this.name, this.picture, this.email, this.isVerifiedEmail, this.phone, this.isVerifiedPhone);
+  DescopeUser(
+      this.userId,
+      this.loginIds,
+      this.createdAt,
+      this.name,
+      this.picture,
+      this.email,
+      this.isVerifiedEmail,
+      this.phone,
+      this.isVerifiedPhone);
 
   static var fromJson = _$DescopeUserFromJson;
   static var toJson = _$DescopeUserToJson;
@@ -99,6 +108,7 @@ class DescopeUser {
 
   @override
   int get hashCode {
-    return Object.hash(userId, loginIds, createdAt, name, picture, email, isVerifiedEmail, phone, isVerifiedPhone);
+    return Object.hash(userId, loginIds, createdAt, name, picture, email,
+        isVerifiedEmail, phone, isVerifiedPhone);
   }
 }


### PR DESCRIPTION
## Related Issues
N/A

## Description
Fixes `DeliveryMethod.email` casing, where it is sometimes listed as `DeliveryMethod.Email` in README, code comments, etc.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

