### PR TITLE
Add DescopeException for structured errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can read more on the [Descope Website](https://descope.com).
 - [Quickstart](#quickstart)
 - [Session Management](#session-management)
 - [Custom Claims](#custom-claims)
-- [Error handling via DescopeException](#error-handling)
+- [Error handling](#error-handling)
 - [Authentication Flows](#running-flows)
 - Authenticate users using the authentication methods that suit your needs:
   - [OTP](#otp-authentication) (one-time password)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can read more on the [Descope Website](https://descope.com).
 - [Quickstart](#quickstart)
 - [Session Management](#session-management)
 - [Custom Claims](#custom-claims)
+- [Error handling via DescopeException](#error-handling)
 - [Authentication Flows](#running-flows)
 - Authenticate users using the authentication methods that suit your needs:
   - [OTP](#otp-authentication) (one-time password)
@@ -18,7 +19,6 @@ You can read more on the [Descope Website](https://descope.com).
   - [OAuth](#oauth) (social)
   - [SSO / SAML](#ssosaml)
   - [Passwords](#password-authentication) (unrecommended form of authentication)
-- [Error handling via DescopeException](#error-handling-via-descopeexception)
 
 ## Quickstart
 
@@ -173,6 +173,36 @@ await Descope.otp.signIn(method: DeliveryMethod.email, loginId: 'desmond_c@mail.
 
 Note that any custom claims added via this method are considered insecure and will
 be nested under the `nsec` custom claim.
+
+## Error Handling
+
+All operations in the Descope SDK will throw a `DescopeException` in the event an error occurs.
+There are several ways to catch and handle a `DescopeException` thrown by a Descope SDK
+operation, and you can use whichever one is more appropriate in each specific use case.
+
+```dart
+try {
+  final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: loginId, code: code);
+  final session = DescopeSession.fromAuthenticationResponse(authResponse);
+  Descope.sessionManager.manageSession(session);
+} on DescopeException catch (e) {
+  switch(e) {
+    case DescopeException.wrongOTPCode:
+    case DescopeException.invalidRequest:
+      showBadCodeAlert();
+      break;
+    case DescopeException.networkError:
+      showNetworkErrorRetry();
+      break;
+    default:
+      showUnexpectedErrorAlert(with: e);
+  }
+}
+```
+
+See the `DescopeException` class for specific error values. Note that not all API errors
+are listed in the SDK yet. Please let us know via a Github issue or pull request if you
+need us to add any entries to make your code simpler.
 
 ## Running Flows
 
@@ -511,35 +541,6 @@ The user can either `sign up` or `sign in`
 final authResponse = await Descope.password.signUp(loginId: 'desmond_c@mail.com', password: 'cleartext-password',
     details: SignUpDetails(name: 'Desmond Copeland'));
 ```
-## Error Handling via `DescopeException`
-
-All of the authentication operations will throw a `DescopeException` in the event an error
-is encountered. There are several ways to catch and handle a `DescopeException` thrown by a Descope SDK
-operation, and you can use whichever one is more appropriate in each specific use case.
-
-```dart
-try {
-  final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: loginId, code: code);
-  final session = DescopeSession.fromAuthenticationResponse(authResponse);
-} on DescopeException catch (e) {
-  switch(e) {
-    case DescopeException.wrongOTPCode:
-    case DescopeException.invalidRequest:
-      showBadCodeAlert();
-    case DescopeException.networkError:
-      showNetworkErrorRetry();
-    default:
-      showUnexpectedErrorAlert(with: e);
-  }
-} catch (e) {
-  // You can have a general catch-all as well
-  showUnexpectedErrorAlert(with: e);
-}
-```
-
-See the `DescopeException` class for specific error values. Note that not all API errors
-are listed in the SDK yet. Please let us know via a Github issue or pull request if you
-need us to add any entries to make your code simpler.
 
 ## Additional Information
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ be nested under the `nsec` custom claim.
 
 ## Error Handling
 
-All operations in the Descope SDK will throw a `DescopeException` in the event an error occurs.
-There are several ways to catch and handle a `DescopeException` thrown by a Descope SDK
-operation, and you can use whichever one is more appropriate in each specific use case.
+All authentication operations throw a `DescopeException` in case of a failure. There are several
+ways to catch and handle a `DescopeException`, and you can use whichever one is more
+appropriate in each specific use case.
 
 ```dart
 try {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can read more on the [Descope Website](https://descope.com).
   - [OAuth](#oauth) (social)
   - [SSO / SAML](#ssosaml)
   - [Passwords](#password-authentication) (unrecommended form of authentication)
+- [Error handling via DescopeException](#error-handling-via-descopeexception)
 
 ## Quickstart
 
@@ -510,6 +511,35 @@ The user can either `sign up` or `sign in`
 final authResponse = await Descope.password.signUp(loginId: 'desmond_c@mail.com', password: 'cleartext-password',
     details: SignUpDetails(name: 'Desmond Copeland'));
 ```
+## Error Handling via `DescopeException`
+
+All of the authentication operations will throw a `DescopeException` in the event an error
+is encountered. There are several ways to catch and handle a `DescopeException` thrown by a Descope SDK
+operation, and you can use whichever one is more appropriate in each specific use case.
+
+```dart
+try {
+  final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: loginId, code: code);
+  final session = DescopeSession.fromAuthenticationResponse(authResponse);
+} on DescopeException catch (e) {
+  switch(e) {
+    case DescopeException.wrongOTPCode:
+    case DescopeException.invalidRequest:
+      showBadCodeAlert();
+    case DescopeException.networkError:
+      showNetworkErrorRetry();
+    default:
+      showUnexpectedErrorAlert(with: e);
+  }
+} catch (e) {
+  // You can have a general catch-all as well
+  showUnexpectedErrorAlert(with: e);
+}
+```
+
+See the `DescopeException` class for specific error values. Note that not all API errors
+are listed in the SDK yet. Please let us know via a Github issue or pull request if you
+need us to add any entries to make your code simpler.
 
 ## Additional Information
 

--- a/lib/descope.dart
+++ b/lib/descope.dart
@@ -19,6 +19,7 @@ export '/src/session/token.dart' show DescopeToken;
 export '/src/types/others.dart';
 export '/src/types/responses.dart';
 export '/src/types/user.dart' show DescopeUser;
+export '/src/types/error.dart';
 
 /// Provides functions for working with the Descope API.
 ///

--- a/lib/src/internal/http/descope_client.dart
+++ b/lib/src/internal/http/descope_client.dart
@@ -1,5 +1,8 @@
+import 'package:descope/src/internal/others/error.dart';
+
 import '/src/sdk/config.dart';
 import '/src/sdk/sdk.dart';
+import '/src/types/error.dart';
 import '/src/types/others.dart';
 import 'http_client.dart';
 import 'responses.dart';
@@ -212,10 +215,13 @@ class DescopeClient extends HttpClient {
   // OAuth
 
   Future<OAuthServerResponse> oauthStart(OAuthProvider provider, String? redirectUrl, SignInOptions? options) {
-    return post('auth/oauth/authorize', OAuthServerResponse.decoder, headers: authorization(options?.refreshJwt), params: {
-      'provider': provider.name,
-      'redirectUrl': redirectUrl,
-    }, body: options?.toMap() ?? {});
+    return post('auth/oauth/authorize', OAuthServerResponse.decoder,
+        headers: authorization(options?.refreshJwt),
+        params: {
+          'provider': provider.name,
+          'redirectUrl': redirectUrl,
+        },
+        body: options?.toMap() ?? {});
   }
 
   Future<JWTServerResponse> oauthExchange(String code) {
@@ -227,10 +233,13 @@ class DescopeClient extends HttpClient {
   // SSO
 
   Future<SsoServerResponse> ssoStart(String emailOrTenantId, String? redirectUrl, SignInOptions? options) {
-    return post('auth/saml/authorize', SsoServerResponse.decoder, headers: authorization(options?.refreshJwt), params: {
-      'tenant': emailOrTenantId,
-      'redirectUrl': redirectUrl,
-    }, body: options?.toMap() ?? {});
+    return post('auth/saml/authorize', SsoServerResponse.decoder,
+        headers: authorization(options?.refreshJwt),
+        params: {
+          'tenant': emailOrTenantId,
+          'redirectUrl': redirectUrl,
+        },
+        body: options?.toMap() ?? {});
   }
 
   Future<JWTServerResponse> ssoExchange(String code) {
@@ -304,7 +313,7 @@ extension on SignUpDetails {
 extension on DeliveryMethod {
   ensurePhoneMethod() {
     if (this != DeliveryMethod.sms && this != DeliveryMethod.whatsapp) {
-      throw Exception('Update phone can be done using SMS or WhatsApp only');
+      throw DescopeException.invalidArguments.add(message: 'Update phone can be done using SMS or WhatsApp only');
     }
   }
 }

--- a/lib/src/internal/http/descope_client.dart
+++ b/lib/src/internal/http/descope_client.dart
@@ -1,5 +1,4 @@
-import 'package:descope/src/internal/others/error.dart';
-
+import '/src/internal/others/error.dart';
 import '/src/sdk/config.dart';
 import '/src/sdk/sdk.dart';
 import '/src/types/error.dart';

--- a/lib/src/internal/others/error.dart
+++ b/lib/src/internal/others/error.dart
@@ -1,0 +1,24 @@
+import '/src/types/error.dart';
+
+extension InternalErrors on DescopeException {
+  /// Thrown if a call to the Descope API fails in an unexpected manner.
+  ///
+  /// This should only be thrown when there's no error response body to parse or the body
+  /// isn't in the expected format. The value of [desc] is overwritten with a more specific
+  /// value when possible.
+  static const httpError = DescopeException(code: 'F010002', desc: 'Server request failed');
+
+  /// Thrown if a response from the Descope API can't be parsed for an unexpected reason.
+  static const decodeError = DescopeException(code: 'F010003', desc: 'Failed to decode response');
+
+  /// Thrown if a request to the Descope API fails to encode for an unexpected reason.
+  static const encodeError = DescopeException(code: 'F010004', desc: 'Failed to encode request');
+
+  /// Thrown if a JWT string fails to decode.
+  ///
+  /// This might be thrown if the `DescopeSession` initializer is called with an invalid
+  /// `sessionJwt` or `refreshJwt` value.
+  static const tokenError = DescopeException(code: 'F010005', desc: 'Failed to parse token');
+
+  DescopeException add({String? desc, String? message, dynamic cause}) => DescopeException(code: code, desc: desc ?? this.desc, message: message ?? this.message, cause: cause ?? this.cause);
+}

--- a/lib/src/internal/routes/enchanted_link.dart
+++ b/lib/src/internal/routes/enchanted_link.dart
@@ -1,8 +1,9 @@
+import '/src/internal/http/descope_client.dart';
+import '/src/internal/http/responses.dart';
 import '/src/sdk/routes.dart';
+import '/src/types/error.dart';
 import '/src/types/others.dart';
 import '/src/types/responses.dart';
-import '../http/descope_client.dart';
-import '../http/responses.dart';
 import 'shared.dart';
 
 const defaultPollDuration = Duration(minutes: 2);
@@ -49,7 +50,7 @@ class EnchantedLink implements DescopeEnchantedLink {
         Future.delayed(const Duration(seconds: 1));
       }
     } while (DateTime.now().difference(start) <= (timeout ?? defaultPollDuration));
-    throw Exception('polling timed out');
+    throw DescopeException.enchantedLinkExpired;
   }
 }
 

--- a/lib/src/internal/routes/shared.dart
+++ b/lib/src/internal/routes/shared.dart
@@ -1,3 +1,5 @@
+import 'package:descope/src/internal/others/error.dart';
+
 import '/src/session/token.dart';
 import '/src/types/others.dart';
 import '/src/types/responses.dart';
@@ -8,10 +10,10 @@ extension ConvertMaskedAddress on MaskedAddressServerResponse {
   String convert(DeliveryMethod method) {
     switch (method) {
       case DeliveryMethod.email:
-        return maskedEmail != null ? maskedEmail! : throw Exception('Missing masked email');
+        return maskedEmail != null ? maskedEmail! : throw InternalErrors.decodeError.add(message: 'Missing masked email');
       case DeliveryMethod.sms:
       case DeliveryMethod.whatsapp:
-        return maskedPhone != null ? maskedPhone! : throw Exception('Missing masked phone');
+        return maskedPhone != null ? maskedPhone! : throw InternalErrors.decodeError.add(message: 'Missing masked phone');
     }
   }
 }
@@ -33,11 +35,11 @@ extension ConvertJWTResponse on JWTServerResponse {
   AuthenticationResponse convert() {
     final refreshJwt = this.refreshJwt;
     if (refreshJwt == null) {
-      throw Exception('Missing refresh JWT');
+      throw InternalErrors.decodeError.add(message: 'Missing refresh JWT');
     }
     final user = this.user;
     if (user == null) {
-      throw Exception('Missing user details');
+      throw InternalErrors.decodeError.add(message: 'Missing user details');
     }
     return AuthenticationResponse(Token.decode(sessionJwt), Token.decode(refreshJwt), firstSeen, user.convert());
   }

--- a/lib/src/internal/routes/shared.dart
+++ b/lib/src/internal/routes/shared.dart
@@ -1,5 +1,4 @@
-import 'package:descope/src/internal/others/error.dart';
-
+import '/src/internal/others/error.dart';
 import '/src/session/token.dart';
 import '/src/types/others.dart';
 import '/src/types/responses.dart';

--- a/lib/src/session/token.dart
+++ b/lib/src/session/token.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:descope/src/internal/others/error.dart';
+import '/src/internal/others/error.dart';
 
 /// A [DescopeToken] is a utility wrapper around a single JWT value.
 ///

--- a/lib/src/types/error.dart
+++ b/lib/src/types/error.dart
@@ -1,0 +1,52 @@
+/// A list of common `DescopeException` values that can be thrown by the Descope SDK.
+class DescopeException implements Exception {
+  /// Thrown when a call to the Descope API fails due to a network error.
+  ///
+  /// You can catch this kind of error to handle error cases such as the user being
+  /// offline or the network request timing out.
+  static const networkError = DescopeException._sdkError(code: 'S010001', desc: 'Network error');
+
+  static const badRequest = DescopeException._apiError(code: 'E011001');
+  static const missingArguments = DescopeException._apiError(code: 'E011002');
+  static const invalidRequest = DescopeException._apiError(code: 'E011003');
+  static const invalidArguments = DescopeException._apiError(code: 'E011004');
+
+  static const wrongOTPCode = DescopeException._apiError(code: 'E061102');
+  static const tooManyOTPAttempts = DescopeException._apiError(code: 'E061103');
+
+  static const enchantedLinkPending = DescopeException._apiError(code: 'E062503');
+  static const enchantedLinkExpired = DescopeException._sdkError(code: 'S060001', desc: 'Enchanted link expired');
+
+  static const flowFailed = DescopeException._sdkError(code: 'S100001', desc: 'Flow failed to run');
+  static const flowCancelled = DescopeException._sdkError(code: 'S100002', desc: 'Flow cancelled');
+
+  final String code;
+  final String desc;
+  final String? message;
+  final dynamic cause;
+
+  const DescopeException({
+    required this.code,
+    required this.desc,
+    this.message,
+    this.cause,
+  });
+
+  const DescopeException._sdkError({
+    required String code,
+    required String desc,
+  }) : this(code: code, desc: desc);
+
+  const DescopeException._apiError({required String code}) : this(code: code, desc: 'Descope API error');
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is DescopeException && other.code == code;
+  }
+
+  @override
+  int get hashCode => Object.hash(code, desc);
+}

--- a/lib/src/types/error.dart
+++ b/lib/src/types/error.dart
@@ -4,7 +4,7 @@ class DescopeException implements Exception {
   ///
   /// You can catch this kind of error to handle error cases such as the user being
   /// offline or the network request timing out.
-  static const networkError = DescopeException._sdkError(code: 'S010001', desc: 'Network error');
+  static const networkError = DescopeException._sdkError(code: 'F010001', desc: 'Network error');
 
   static const badRequest = DescopeException._apiError(code: 'E011001');
   static const missingArguments = DescopeException._apiError(code: 'E011002');
@@ -15,10 +15,10 @@ class DescopeException implements Exception {
   static const tooManyOTPAttempts = DescopeException._apiError(code: 'E061103');
 
   static const enchantedLinkPending = DescopeException._apiError(code: 'E062503');
-  static const enchantedLinkExpired = DescopeException._sdkError(code: 'S060001', desc: 'Enchanted link expired');
+  static const enchantedLinkExpired = DescopeException._sdkError(code: 'F060001', desc: 'Enchanted link expired');
 
-  static const flowFailed = DescopeException._sdkError(code: 'S100001', desc: 'Flow failed to run');
-  static const flowCancelled = DescopeException._sdkError(code: 'S100002', desc: 'Flow cancelled');
+  static const flowFailed = DescopeException._sdkError(code: 'F100001', desc: 'Flow failed to run');
+  static const flowCancelled = DescopeException._sdkError(code: 'F100002', desc: 'Flow cancelled');
 
   final String code;
   final String desc;

--- a/lib/src/types/error.dart
+++ b/lib/src/types/error.dart
@@ -1,5 +1,28 @@
-/// A list of common `DescopeException` values that can be thrown by the Descope SDK.
+/// The concrete type of `Exception` thrown by all operations in the Descope SDK.
+///
+/// There are several ways to catch and handle a `DescopeException` thrown by a Descope SDK
+/// operation, and you can use whichever one is more appropriate in each specific use case.
+///
+///     try {
+///       final authResponse = await Descope.otp.verify(method: DeliveryMethod.email, loginId: loginId, code: code);
+///       final session = DescopeSession.fromAuthenticationResponse(authResponse);
+///     } on DescopeException catch (e) {
+///       switch(e) {
+///         case DescopeException.wrongOTPCode:
+///         case DescopeException.invalidRequest:
+///           showBadCodeAlert();
+///         case DescopeException.networkError:
+///           showNetworkErrorRetry();
+///         default:
+///           showUnexpectedErrorAlert(with: e);
+///       }
+///     } catch (e) {
+///       // You can have a general catch-all as well
+///       showUnexpectedErrorAlert(with: e);
+///     }
 class DescopeException implements Exception {
+  // A list of common `DescopeException` values that can be thrown by the Descope SDK.
+
   /// Thrown when a call to the Descope API fails due to a network error.
   ///
   /// You can catch this kind of error to handle error cases such as the user being
@@ -20,9 +43,27 @@ class DescopeException implements Exception {
   static const flowFailed = DescopeException._sdkError(code: 'F100001', desc: 'Flow failed to run');
   static const flowCancelled = DescopeException._sdkError(code: 'F100002', desc: 'Flow cancelled');
 
+  /// A string of 7 characters that represents a specific Descope error.
+  ///
+  /// For example, the value of [code] is `"E011003"` when an API request fails validation.
   final String code;
+
+  /// A short description of the error message.
+  ///
+  /// For example, the value of [desc] is `"Request is invalid"` when an API request
+  /// fails validation.
   final String desc;
+
+  /// An optional message with more details about the error.
+  ///
+  /// For example, the value of [message] might be `"The email field is required"` when
+  /// attempting to authenticate via enchanted link with an empty email address.
   final String? message;
+
+  /// An optional underlying error that caused this error.
+  ///
+  /// For example, when a [DescopeException.networkError] is caught the [cause] property
+  /// will usually have the object thrown by the internal `http.Request` call.
   final dynamic cause;
 
   const DescopeException({

--- a/lib/src/types/error.dart
+++ b/lib/src/types/error.dart
@@ -11,14 +11,13 @@
 ///         case DescopeException.wrongOTPCode:
 ///         case DescopeException.invalidRequest:
 ///           showBadCodeAlert();
+///           break;
 ///         case DescopeException.networkError:
 ///           showNetworkErrorRetry();
+///           break;
 ///         default:
 ///           showUnexpectedErrorAlert(with: e);
 ///       }
-///     } catch (e) {
-///       // You can have a general catch-all as well
-///       showUnexpectedErrorAlert(with: e);
 ///     }
 class DescopeException implements Exception {
   // A list of common `DescopeException` values that can be thrown by the Descope SDK.


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/3796

## Description
Add `DescopeException`. From now on, all errors thrown by the Flutter SDK will be structured.

## Must
- [X] Tests
- [X] Documentation (if applicable)

