### PR TITLE
Replace config and projectId setters with setup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,19 @@ the Descope Console.
 import 'package:descope/descope.dart';
 
 // Where your application state is being created
-Descope.projectId = '<Your-Project-ID>';
+Descope.setup('<Your-Project-ID>');
+
+// Optionally, you can configure your SDK to your needs
+Descope.setup('<Your-Project-Id>', (config) {
+  // set a custom base URL (needs to be set up in the Descope console)
+  config.baseUrl = 'https://my.app.com';
+  // enable the logger
+  if (kDebugMode) {
+    config.logger = DescopeLogger();
+  }
+});
+
+// Load any available sessions
 await Descope.sessionManager.loadSession();
 ```
 
@@ -130,7 +142,7 @@ initialized first:
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  Descope.projectId = '...';
+  Descope.setup('...');
   await Descope.sessionManager.loadSession();
 
   final session = Descope.sessionManager.session;

--- a/lib/descope.dart
+++ b/lib/descope.dart
@@ -26,32 +26,20 @@ export '/src/types/error.dart';
 /// This singleton object is provided as a convenience that should be suitable for most
 /// app architectures. If you prefer a different approach you can also create an instance
 /// of the [DescopeSdk] class instead.
+///
+/// - **Important**: Make sure to call the [setup] function when initializing your application.
 class Descope {
-  /// The projectId of your Descope project.
+  /// The setup of the `Descope` singleton.
   ///
-  /// You will most likely want to set this value in your application's initialization code,
-  /// and in most cases you only need to set this to work with the `Descope` singleton.
+  /// Call this function when initializing you application.
   ///
-  /// **Note:** This is a shortcut for setting the [Descope.config] property.
-  static String get projectId => _config.projectId;
-
-  static set projectId(String projectId) {
-    _config = DescopeConfig(projectId: projectId);
-  }
-
-  /// The configuration of the `Descope` singleton.
+  /// **This function must be called before the [Descope] object can be used**
   ///
-  /// Set this property **instead** of [Descope.projectId] in your application's initialization code
-  /// if you require additional configuration.
-  ///
-  /// **Important:** To prevent accidental misuse only one of `config` and `projectId` can
-  /// be set, and they can only be set once. If this isn't appropriate for your use
-  /// case you can also use the [DescopeSdk] class directly instead.
-  static DescopeConfig get config => _config;
-
-  static set config(DescopeConfig config) {
-    assert(_config.projectId == '');
-    _config = config;
+  /// The [projectId] of the Descope project can be found in the project page in
+  /// the Descope console. Use the optional [configure] function to
+  /// finely configure the Descope SDK.
+  static void setup(String projectId, [Function(DescopeConfig)? configure]) {
+    _sdk = DescopeSdk(projectId, configure);
   }
 
   /// Manages the storage and lifetime of a [DescopeSession].
@@ -100,11 +88,8 @@ class Descope {
   /// Authentication with passwords.
   static DescopePassword get password => _sdk.password;
 
-  // The backing field for the config property.
-  static DescopeConfig _config = DescopeConfig.initial;
-
   // The underlying DescopeSdk object used by the Descope singleton.
-  static final DescopeSdk _sdk = DescopeSdk(config);
+  static late final DescopeSdk _sdk;
 
   // This class cannot be instantiated.
   Descope._();

--- a/lib/src/sdk/config.dart
+++ b/lib/src/sdk/config.dart
@@ -6,10 +6,11 @@ import '/src/sdk/sdk.dart';
 /// The configuration of the Descope SDK.
 class DescopeConfig {
   /// The id of the Descope project.
-  final String projectId;
+  String projectId;
 
-  /// An optional override for the base URL of the Descope server.
-  final String? baseUrl;
+  /// An optional override for the base URL of the Descope server,
+  /// in case you need to access it through a CNAME record.
+  String? baseUrl;
 
   /// An optional object to handle logging in the Descope SDK.
   ///
@@ -22,7 +23,7 @@ class DescopeConfig {
   /// If your application uses some logging framework or third party service you can forward
   /// the Descope SDK log messages to it by creating a new subclass of [DescopeLogger] and
   /// overriding the [DescopeLogger.output] method.
-  final DescopeLogger? logger;
+  DescopeLogger? logger;
 
   /// An optional object to override how HTTP requests are performed.
   ///
@@ -32,12 +33,10 @@ class DescopeConfig {
   /// This property can be useful to test code that uses the Descope SDK without any
   /// network requests actually taking place. In most other cases there shouldn't be
   /// any need to use it.
-  final DescopeNetworkClient? networkClient;
+  DescopeNetworkClient? networkClient;
 
   /// Creates a new `DescopeConfig` object.
   DescopeConfig({required this.projectId, this.baseUrl, this.logger, this.networkClient});
-
-  static DescopeConfig initial = DescopeConfig(projectId: '');
 }
 
 /// The [DescopeLogger] class can be used to customize logging functionality in the Descope SDK.

--- a/lib/src/sdk/sdk.dart
+++ b/lib/src/sdk/sdk.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated
 import '/src/internal/http/descope_client.dart';
 import '/src/internal/routes/auth.dart';
 import '/src/internal/routes/enchanted_link.dart';
@@ -56,28 +57,22 @@ class DescopeSdk {
   /// Authentication with passwords
   final DescopePassword password;
 
-  // defer initialization to allow setting a custom manager without loading the current state
-  DescopeSessionManager? _sessionManager;
+  DescopeSessionManager sessionManager;
 
-  DescopeSessionManager get sessionManager => _sessionManager ?? _initDefaultManager();
-
-  set sessionManager(DescopeSessionManager manager) => _sessionManager = manager;
-
-  DescopeSessionManager _initDefaultManager() {
-    final manager = DescopeSessionManager(SessionStorage(projectId: config.projectId), SessionLifecycle(auth));
-    _sessionManager = manager;
-    return manager;
-  }
-
-  /// Creates a new [DescopeSdk] instance with the given [DescopeConfig].
+  /// Creates a new [DescopeSdk].
   ///
   /// The [projectId] of the Descope project can be found in the project page in
-  /// the Descope console. The [baseUrl] is an  optional override for the URL of
-  /// the Descope server, in case you need to access it through a CNAME record.
-  factory DescopeSdk(DescopeConfig config) {
+  /// the Descope console. Use the optional [configure] function to
+  /// finely configure the Descope SDK.
+  factory DescopeSdk(String projectId, [Function(DescopeConfig)? configure]) {
+    // init config
+    final config = DescopeConfig(projectId: projectId);
+    configure?.call(config);
+    // init auth methods
     final client = DescopeClient(config);
     return DescopeSdk._internal(config, Flow(client), Auth(client), Otp(client), Totp(client), MagicLink(client), EnchantedLink(client), OAuth(client), Sso(client), Passkey(client), Password(client));
   }
 
-  DescopeSdk._internal(this.config, this.flow, this.auth, this.otp, this.totp, this.magicLink, this.enchantedLink, this.oauth, this.sso, this.passkey, this.password);
+  DescopeSdk._internal(this.config, this.flow, this.auth, this.otp, this.totp, this.magicLink, this.enchantedLink, this.oauth, this.sso, this.passkey, this.password) :
+    sessionManager = DescopeSessionManager(SessionStorage(projectId: config.projectId), SessionLifecycle(auth));
 }

--- a/lib/src/session/manager.dart
+++ b/lib/src/session/manager.dart
@@ -94,7 +94,7 @@ class DescopeSessionManager {
   ///     void main() async {
   ///       WidgetsFlutterBinding.ensureInitialized();
   ///
-  ///       Descope.projectId = '...';
+  ///       Descope.setup('...');
   ///       await Descope.sessionManager.loadSession();
   ///       ...
   ///     }


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/5672

## Description
Replace config and projectId setters with setup function

**NOTE:** _This is a compilation breaking change as the SDK setup syntax has changed, but not from a logical perspective_

## Must
- [x] Tests
- [x] Documentation (if applicable)

