### PR TITLE
Add option to logout all previous JWTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ if (refreshJwt != null) {
 }
 ```
 
+When the user wants to revoke previously created sessions, also from other devices:
+
+```dart
+final refreshJwt = Descope.sessionManager.session?.refreshJwt;
+if (refreshJwt != null) {
+  Descope.auth.logoutPrevious(refreshJwt);
+}
+```
+
 You can customize how the `DescopeSessionManager` behaves by using
 your own `storage` and `lifecycle` objects. See the documentation
 for more details.

--- a/lib/src/internal/http/descope_client.dart
+++ b/lib/src/internal/http/descope_client.dart
@@ -348,6 +348,10 @@ class DescopeClient extends HttpClient {
     return post('auth/logout', emptyResponse, headers: authorization(refreshJwt));
   }
 
+  Future<void> logoutPrevious(String refreshJwt) {
+    return post('auth/logoutprevious', emptyResponse, headers: authorization(refreshJwt));
+  }
+
   // Internal
 
   @override

--- a/lib/src/internal/routes/auth.dart
+++ b/lib/src/internal/routes/auth.dart
@@ -23,4 +23,9 @@ class Auth implements DescopeAuth {
   Future<void> logout(String refreshJwt) {
     return client.logout(refreshJwt);
   }
+
+  @override
+  Future<void> logoutPrevious(String refreshJwt) {
+    return client.logoutPrevious(refreshJwt);
+  }
 }

--- a/lib/src/sdk/routes.dart
+++ b/lib/src/sdk/routes.dart
@@ -21,6 +21,9 @@ abstract class DescopeAuth {
 
   /// Logs out from an active [DescopeSession].
   Future<void> logout(String refreshJwt);
+
+  /// Revokes all previous created sessions [DescopeSession].
+  Future<void> logoutPrevious(String refreshJwt);
 }
 
 /// Authenticate a user using a flow.


### PR DESCRIPTION
This new function call, will expire all jwts created prior to the one in the request related to https://github.com/descope/etc/issues/8242
