### PR TITLE
External token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.8
+
+- Support external token in `AuthenticationResponse`
+
 # 0.9.7
 
 - Fix user deserialization

--- a/lib/src/internal/http/responses.dart
+++ b/lib/src/internal/http/responses.dart
@@ -14,8 +14,9 @@ class JWTServerResponse {
   String? refreshJwt;
   UserResponse? user;
   bool firstSeen;
+  String? externalToken;
 
-  JWTServerResponse(this.sessionJwt, this.refreshJwt, this.user, this.firstSeen);
+  JWTServerResponse(this.sessionJwt, this.refreshJwt, this.user, this.firstSeen, this.externalToken);
   static var fromJson = _$JWTServerResponseFromJson;
   static var decoder = _parseHeaders(fromJson, (response, headers) {
     final cookies = _cookiesFromHeaders(headers);

--- a/lib/src/internal/http/responses.g.dart
+++ b/lib/src/internal/http/responses.g.dart
@@ -14,6 +14,7 @@ JWTServerResponse _$JWTServerResponseFromJson(Map<String, dynamic> json) =>
           ? null
           : UserResponse.fromJson(json['user'] as Map<String, dynamic>),
       json['firstSeen'] as bool,
+      json['externalToken'] as String?,
     );
 
 UserResponse _$UserResponseFromJson(Map<String, dynamic> json) => UserResponse(

--- a/lib/src/internal/routes/shared.dart
+++ b/lib/src/internal/routes/shared.dart
@@ -65,7 +65,7 @@ extension ConvertJWTResponse on JWTServerResponse {
       throw InternalErrors.decodeError.add(message: 'Missing user details');
     }
 
-    return AuthenticationResponse(sessionToken, refreshToken, firstSeen, user.convert());
+    return AuthenticationResponse(sessionToken, refreshToken, firstSeen, user.convert(), externalToken);
   }
 
   RefreshResponse toRefreshResponse() {

--- a/lib/src/sdk/sdk.dart
+++ b/lib/src/sdk/sdk.dart
@@ -22,7 +22,7 @@ class DescopeSdk {
   static const name = 'DescopeFlutter';
 
   /// The Descope SDK version
-  static const version = '0.9.7';
+  static const version = '0.9.8';
 
   /// The configuration of the [DescopeSdk] instance.
   final DescopeConfig config;

--- a/lib/src/types/responses.dart
+++ b/lib/src/types/responses.dart
@@ -17,7 +17,7 @@ class AuthenticationResponse {
   /// Information about the user.
   final DescopeUser user;
 
-  /// An optional external token, if configured to be returned by the authentication method.
+  /// A value for an external token if the authentication returns it.
   final String? externalToken;
 
   AuthenticationResponse(this.sessionToken, this.refreshToken, this.isFirstAuthentication, this.user, this.externalToken);

--- a/lib/src/types/responses.dart
+++ b/lib/src/types/responses.dart
@@ -17,7 +17,10 @@ class AuthenticationResponse {
   /// Information about the user.
   final DescopeUser user;
 
-  AuthenticationResponse(this.sessionToken, this.refreshToken, this.isFirstAuthentication, this.user);
+  /// An optional external token, if configured to be returned by the authentication method.
+  final String? externalToken;
+
+  AuthenticationResponse(this.sessionToken, this.refreshToken, this.isFirstAuthentication, this.user, this.externalToken);
 }
 
 /// Returned from the refreshSession call.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: descope
 description: A Flutter package for working with the Descope API.
-version: 0.9.7
+version: 0.9.8
 homepage: https://www.descope.com
 repository: https://github.com/descope/descope-flutter
 issue_tracker: https://github.com/descope/descope-flutter/issues


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/11963

## Description
- Add external token to authentication responses to be available if returned in the response
- Bump version to 0.9.8

## Must
- [x] Tests
- [x] Documentation (if applicable)

