### PR TITLE
feat: support authenticated flows in DescopeFlowView

### DIFF
--- a/android/src/main/kotlin/com/descope/flutter/DescopeFlowViewWrapper.kt
+++ b/android/src/main/kotlin/com/descope/flutter/DescopeFlowViewWrapper.kt
@@ -7,6 +7,7 @@ import com.descope.android.DescopeFlow
 import com.descope.android.DescopeFlowHook
 import com.descope.android.DescopeFlowView
 import com.descope.android.runJavaScript
+import com.descope.session.DescopeSession
 import com.descope.types.AuthenticationResponse
 import com.descope.types.DescopeException
 import com.descope.types.DescopeUser
@@ -38,9 +39,12 @@ class DescopeFlowViewWrapper(
         setMethodCallHandler(this@DescopeFlowViewWrapper)
     }
 
+    private var hostSession: DescopeSession? = makeHostSession((args as? Map<*, *>)?.get("session") as? Map<*, *>)
+
     private val flowView = DescopeFlowView(context).apply {
         // init DescopeFlow from args
         val descopeFlow = args.toDescopeFlow()
+        descopeFlow.sessionProvider = { hostSession }
 
         // pipe listener callbacks through a flutter channel
         listener = object : DescopeFlowView.Listener {
@@ -78,6 +82,7 @@ class DescopeFlowViewWrapper(
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "resumeFromDeepLink" -> resumeFromDeepLink(call, result)
+            "updateSession" -> updateSession(call, result)
             else -> result.notImplemented()
         }
     }
@@ -89,6 +94,24 @@ class DescopeFlowViewWrapper(
             result.success(url)
         } catch (ignored: Exception) {
             result.error("INVALIDARGS", "url argument is invalid", null)
+        }
+    }
+
+    private fun updateSession(call: MethodCall, result: Result) {
+        val sessionJwt = call.argument<String>("sessionJwt")
+        val refreshJwt = call.argument<String>("refreshJwt")
+        hostSession = makeHostSession(mapOf("sessionJwt" to sessionJwt, "refreshJwt" to refreshJwt))
+        result.success(null)
+    }
+
+    private fun makeHostSession(map: Map<*, *>?): DescopeSession? {
+        val sessionJwt = map?.get("sessionJwt") as? String
+        val refreshJwt = map?.get("refreshJwt") as? String
+        if (sessionJwt.isNullOrEmpty() || refreshJwt.isNullOrEmpty()) return null
+        return try {
+            DescopeSession(sessionJwt, refreshJwt, DescopeUser.placeholder)
+        } catch (_: Exception) {
+            null
         }
     }
 

--- a/ios/Classes/FlutterDescopeFlowView.swift
+++ b/ios/Classes/FlutterDescopeFlowView.swift
@@ -46,10 +46,14 @@ class DescopeFlowViewWrapper: DescopeFlowView, DescopeFlowViewDelegate {
       }
     }
 
+    private var hostSession: DescopeSession?
+
     func start(_ config: [String : Any]) {
         delegate = self
         guard let url = config["url"] as? String else { return }
         guard let sdkVersion = config["sdkVersion"] as? String else { return }
+
+        hostSession = makeHostSession(from: config["session"] as? [String: Any])
 
         let descopeFlow = DescopeFlow(url: url)
         if let oauthNativeProvider = config["iosOAuthNativeProvider"] as? String {
@@ -69,6 +73,8 @@ class DescopeFlowViewWrapper: DescopeFlowView, DescopeFlowViewDelegate {
             """),
         ]
 
+        descopeFlow.sessionProvider = { [weak self] in self?.hostSession }
+
         start(flow: descopeFlow)
     }
 
@@ -77,6 +83,8 @@ class DescopeFlowViewWrapper: DescopeFlowView, DescopeFlowViewDelegate {
         switch call.method {
         case "resumeFromDeepLink":
             resumeFromDeepLink(call: call, result: result)
+        case "updateSession":
+            updateSession(call: call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -86,6 +94,19 @@ class DescopeFlowViewWrapper: DescopeFlowView, DescopeFlowViewDelegate {
         guard let args = call.arguments as? [String: Any], let urlString = args["url"] as? String, let url = URL(string: urlString) else { return result(FlutterError(code: "MISSINGARGS", message: "'url' is required for resumeFromDeepLink", details: nil)) }
         Descope.handleURL(url)
         result(urlString)
+    }
+
+    private func updateSession(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        hostSession = makeHostSession(from: call.arguments as? [String: Any])
+        result(nil)
+    }
+
+    private func makeHostSession(from dict: [String: Any]?) -> DescopeSession? {
+        guard let dict,
+              let sessionJwt = dict["sessionJwt"] as? String,
+              let refreshJwt = dict["refreshJwt"] as? String,
+              !sessionJwt.isEmpty, !refreshJwt.isEmpty else { return nil }
+        return try? DescopeSession(sessionJwt: sessionJwt, refreshJwt: refreshJwt, user: .placeholder)
     }
 
     // DescopeFlowViewDelegate

--- a/lib/descope.dart
+++ b/lib/descope.dart
@@ -16,6 +16,7 @@ export '/src/sdk/config.dart' show DescopeConfig, DescopeLogger, DescopeNetworkC
 export '/src/sdk/routes.dart';
 export '/src/sdk/sdk.dart' show DescopeSdk;
 export '/src/session/lifecycle.dart' show DescopeSessionLifecycle, SessionLifecycle;
+export '/src/session/manager.dart' show DescopeSessionManager, DescopeSessionManagerListener;
 export '/src/session/session.dart' show DescopeSession;
 export '/src/session/storage.dart' show DescopeSessionStorage, SessionStorage, SessionStorageStore;
 export '/src/session/token.dart' show DescopeToken;

--- a/lib/src/flow/descope_flow_config.dart
+++ b/lib/src/flow/descope_flow_config.dart
@@ -56,7 +56,10 @@ class DescopeFlowConfig {
   /// during execution. The values must be valid JSON types.
   Map<String, dynamic>? clientInputs;
 
-  DescopeFlowConfig({required this.url, this.androidOAuthNativeProvider, this.iosOAuthNativeProvider, this.oauthRedirect, this.oauthRedirectCustomScheme, this.ssoRedirect, this.ssoRedirectCustomScheme, this.magicLinkRedirect, this.clientInputs});
+  /// Provide an instance of [DescopeSdk] if a custom instance was initialized. Leave `null` to use [Descope]
+  DescopeSdk? sdk;
+
+  DescopeFlowConfig({required this.url, this.androidOAuthNativeProvider, this.iosOAuthNativeProvider, this.oauthRedirect, this.oauthRedirectCustomScheme, this.ssoRedirect, this.ssoRedirectCustomScheme, this.magicLinkRedirect, this.clientInputs, this.sdk});
 
   /// Creates a [DescopeFlowConfig] with a URL built from the flow ID, for use with
   /// Descope's Flow hosting service.
@@ -70,9 +73,9 @@ class DescopeFlowConfig {
   /// The optional [sdk] parameter can be provided to use a specific [DescopeSdk] instance
   /// instead of the [Descope] singleton.
   factory DescopeFlowConfig.hosted(String flowId, {DescopeSdk? sdk}) {
-    final config = (sdk ?? globalSdk).config;
-    final baseUrl = config.baseUrl ?? baseUrlForProjectId(config.projectId);
-    return DescopeFlowConfig(url: '$baseUrl/login/${config.projectId}?wide=true&platform=mobile&flow=$flowId');
+    final descope = sdk ?? globalSdk;
+    final baseUrl = descope.config.baseUrl ?? baseUrlForProjectId(descope.config.projectId);
+    return DescopeFlowConfig(url: '$baseUrl/login/${descope.config.projectId}?wide=true&platform=mobile&flow=$flowId', sdk: sdk);
   }
 
 }

--- a/lib/src/flow/descope_flow_view_native.dart
+++ b/lib/src/flow/descope_flow_view_native.dart
@@ -128,6 +128,7 @@ class _DescopeFlowViewState extends State<DescopeFlowView> implements DescopeSes
   static const String _viewType = 'descope_flutter/descope_flow_view';
 
   MethodChannel? _channel;
+  DescopeSessionManager? _subscribedManager;
   DescopeFlowController? get _controller => _isMobilePlatform() ? widget.controller : null;
   DescopeSdk get _sdk => widget.config.sdk ?? globalSdk;
 
@@ -181,14 +182,32 @@ class _DescopeFlowViewState extends State<DescopeFlowView> implements DescopeSes
   void initState() {
     super.initState();
     _controller?._attach(this);
-    _sdk.sessionManager.addListener(this);
+    _subscribeToSessionManager();
+  }
+
+  @override
+  void didUpdateWidget(DescopeFlowView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final currentManager = _sdk.sessionManager;
+    if (!identical(currentManager, _subscribedManager)) {
+      _subscribedManager?.removeListener(this);
+      _subscribedManager = currentManager;
+      currentManager.addListener(this);
+    }
   }
 
   @override
   void dispose() {
-    _sdk.sessionManager.removeListener(this);
+    _subscribedManager?.removeListener(this);
+    _subscribedManager = null;
     _controller?._detach();
     super.dispose();
+  }
+
+  void _subscribeToSessionManager() {
+    final manager = _sdk.sessionManager;
+    _subscribedManager = manager;
+    manager.addListener(this);
   }
 
   @override

--- a/lib/src/flow/descope_flow_view_native.dart
+++ b/lib/src/flow/descope_flow_view_native.dart
@@ -8,7 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '/src/sdk/sdk.dart';
+import '/src/session/manager.dart';
+import '/src/session/session.dart';
 import '/src/types/error.dart';
+import '/src/types/responses.dart';
 import '/src/flow/descope_flow_callbacks.dart';
 import '/src/flow/descope_flow_config.dart';
 
@@ -88,6 +91,22 @@ class DescopeFlowController {
 /// `Client Secret` should be set to the values of your `Web application` OAuth client,
 /// rather than those from the `Android` OAuth client.
 /// For more details about configuring your app see the [Credential Manager documentation](https://developer.android.com/identity/sign-in/credential-manager).
+///
+/// **Authenticated Flows**
+///
+/// This is used when running a flow that expects the user to already be signed in.
+/// For example, a flow to update a user's email or account recovery details, or that
+/// does step-up authentication.
+///
+/// The default behavior is to check whether the [DescopeSessionManager] is currently
+/// managing a valid session, and forward it to the flow if that's the case.
+///
+/// **Note**: The default behavior checks the [DescopeSessionManager] from the [Descope]
+/// singleton, or the one from the config's [DescopeFlowConfig.sdk] property if it is set.
+///
+/// **Important**: The session may be read multiple times to ensure that the flow uses
+/// the newest tokens, even if the session is refreshed while the flow is running.
+/// This is especially important for projects that use refresh token rotation.
 class DescopeFlowView extends StatefulWidget {
   final DescopeFlowConfig config;
   final DescopeFlowCallbacks? callbacks;
@@ -104,12 +123,13 @@ class DescopeFlowView extends StatefulWidget {
   State<DescopeFlowView> createState() => _DescopeFlowViewState();
 }
 
-class _DescopeFlowViewState extends State<DescopeFlowView> {
+class _DescopeFlowViewState extends State<DescopeFlowView> implements DescopeSessionManagerListener {
 
   static const String _viewType = 'descope_flutter/descope_flow_view';
 
   MethodChannel? _channel;
   DescopeFlowController? get _controller => _isMobilePlatform() ? widget.controller : null;
+  DescopeSdk get _sdk => widget.config.sdk ?? globalSdk;
 
   // State implementation
 
@@ -118,6 +138,7 @@ class _DescopeFlowViewState extends State<DescopeFlowView> {
     // only supported on mobile platforms
     if (_rejectNonMobilePlatform()) return const SizedBox.shrink();
 
+    final activeSession = _sdk.sessionManager.session;
     final clientInputs = widget.config.clientInputs;
     final params = <String, dynamic>{
       'url': widget.config.url,
@@ -130,6 +151,11 @@ class _DescopeFlowViewState extends State<DescopeFlowView> {
       'magicLinkRedirect': widget.config.magicLinkRedirect,
       'clientInputs': clientInputs == null ? null : (Map.of(clientInputs)..removeWhere((_, v) => v == null)),
       'sdkVersion': DescopeSdk.version,
+      if (activeSession != null)
+        'session': {
+          'sessionJwt': activeSession.sessionJwt,
+          'refreshJwt': activeSession.refreshJwt,
+        },
     };
 
     if (defaultTargetPlatform == TargetPlatform.android) {
@@ -155,13 +181,26 @@ class _DescopeFlowViewState extends State<DescopeFlowView> {
   void initState() {
     super.initState();
     _controller?._attach(this);
+    _sdk.sessionManager.addListener(this);
   }
 
   @override
   void dispose() {
+    _sdk.sessionManager.removeListener(this);
     _controller?._detach();
     super.dispose();
   }
+
+  @override
+  void onUpdateTokens(DescopeSession session) {
+    _channel?.invokeMethod('updateSession', {
+      'sessionJwt': session.sessionJwt,
+      'refreshJwt': session.refreshJwt,
+    });
+  }
+
+  @override
+  void onUpdateUser(DescopeSession session) {}
 
   // Internal
 
@@ -176,7 +215,19 @@ class _DescopeFlowViewState extends State<DescopeFlowView> {
         case 'onSuccess':
           try {
             final payload = _coercePayload(call.arguments);
-            final authenticationResponse = JWTServerResponse.fromJson(payload).toAuthenticationResponse();
+            var authenticationResponse = JWTServerResponse.fromJson(payload).toAuthenticationResponse();
+            if (authenticationResponse.user.userId.isEmpty) {
+              final activeUser = _sdk.sessionManager.session?.user;
+              if (activeUser != null) {
+                authenticationResponse = AuthenticationResponse(
+                  authenticationResponse.sessionToken,
+                  authenticationResponse.refreshToken,
+                  authenticationResponse.isFirstAuthentication,
+                  activeUser,
+                  authenticationResponse.externalToken,
+                );
+              }
+            }
             widget.callbacks?.onSuccess?.call(authenticationResponse);
           } catch (e) {
             widget.callbacks?.onError?.call(DescopeException.flowFailed.add(message: "Unexpected success payload", cause: e));

--- a/lib/src/flow/descope_flow_view_native.dart
+++ b/lib/src/flow/descope_flow_view_native.dart
@@ -128,7 +128,6 @@ class _DescopeFlowViewState extends State<DescopeFlowView> implements DescopeSes
   static const String _viewType = 'descope_flutter/descope_flow_view';
 
   MethodChannel? _channel;
-  DescopeSessionManager? _subscribedManager;
   DescopeFlowController? get _controller => _isMobilePlatform() ? widget.controller : null;
   DescopeSdk get _sdk => widget.config.sdk ?? globalSdk;
 
@@ -182,32 +181,14 @@ class _DescopeFlowViewState extends State<DescopeFlowView> implements DescopeSes
   void initState() {
     super.initState();
     _controller?._attach(this);
-    _subscribeToSessionManager();
-  }
-
-  @override
-  void didUpdateWidget(DescopeFlowView oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    final currentManager = _sdk.sessionManager;
-    if (!identical(currentManager, _subscribedManager)) {
-      _subscribedManager?.removeListener(this);
-      _subscribedManager = currentManager;
-      currentManager.addListener(this);
-    }
+    _sdk.sessionManager.addListener(this);
   }
 
   @override
   void dispose() {
-    _subscribedManager?.removeListener(this);
-    _subscribedManager = null;
+    _sdk.sessionManager.removeListener(this);
     _controller?._detach();
     super.dispose();
-  }
-
-  void _subscribeToSessionManager() {
-    final manager = _sdk.sessionManager;
-    _subscribedManager = manager;
-    manager.addListener(this);
   }
 
   @override

--- a/lib/src/session/manager.dart
+++ b/lib/src/session/manager.dart
@@ -4,6 +4,16 @@ import 'lifecycle.dart';
 import 'session.dart';
 import 'storage.dart';
 
+/// A set of listener methods for events about the session managed by a [DescopeSessionManager].
+abstract class DescopeSessionManagerListener {
+  /// Called after the session tokens are updated due to a successful refresh or by
+  /// a call to [DescopeSessionManager.updateTokens].
+  void onUpdateTokens(DescopeSession session);
+
+  /// Called after the session is updated via [DescopeSessionManager.updateUser]
+  void onUpdateUser(DescopeSession session);
+}
+
 /// The `DescopeSessionManager` class is used to manage an authenticated
 /// user session for an application.
 ///
@@ -120,9 +130,16 @@ class DescopeSessionManager {
   /// unless they use custom `storage` objects they might overwrite
   /// each other's saved sessions.
   void manageSession(DescopeSession session) {
+    final previous = _session;
     _session = session;
     lifecycle.session = session;
     storage.saveSession(session);
+    if (previous?.sessionJwt != session.sessionJwt || previous?.refreshJwt != session.refreshJwt) {
+      _notifyTokens(session);
+    }
+    if (previous?.user != session.user) {
+      _notifyUser(session);
+    }
   }
 
   /// Clears any active [DescopeSession] from this manager.
@@ -153,9 +170,26 @@ class DescopeSessionManager {
   Future<void> refreshSessionIfNeeded() async {
     final session = _session;
     if (session != null) {
+      final beforeSession = session.sessionJwt;
+      final beforeRefresh = session.refreshJwt;
       await lifecycle.refreshSessionIfNeeded();
       await storage.saveSession(session);
+      if (beforeSession != session.sessionJwt || beforeRefresh != session.refreshJwt) {
+        _notifyTokens(session);
+      }
     }
+  }
+
+  /// Adds a listener object to the session manager.
+  void addListener(DescopeSessionManagerListener listener) {
+    if (!_listeners.contains(listener)) {
+      _listeners.add(listener);
+    }
+  }
+
+  /// Removes a listener object that was previously added.
+  void removeListener(DescopeSessionManagerListener listener) {
+    _listeners.remove(listener);
   }
 
   /// Updates the active session's underlying JWTs.
@@ -175,6 +209,7 @@ class DescopeSessionManager {
     if (session != null) {
       session.updateTokens(refreshResponse);
       storage.saveSession(session);
+      _notifyTokens(session);
     }
   }
 
@@ -191,6 +226,7 @@ class DescopeSessionManager {
     if (session != null) {
       session.updateUser(user);
       storage.saveSession(session);
+      _notifyUser(session);
     }
   }
 
@@ -198,6 +234,21 @@ class DescopeSessionManager {
     final session = _session;
     if (session != null) {
       storage.saveSession(session);
+      _notifyTokens(session);
+    }
+  }
+
+  final List<DescopeSessionManagerListener> _listeners = [];
+
+  void _notifyTokens(DescopeSession session) {
+    for (final listener in List<DescopeSessionManagerListener>.from(_listeners)) {
+      listener.onUpdateTokens(session);
+    }
+  }
+
+  void _notifyUser(DescopeSession session) {
+    for (final listener in List<DescopeSessionManagerListener>.from(_listeners)) {
+      listener.onUpdateUser(session);
     }
   }
 }

--- a/lib/src/session/manager.dart
+++ b/lib/src/session/manager.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '/src/types/responses.dart';
 import '/src/types/user.dart';
 import 'lifecycle.dart';
@@ -244,31 +242,13 @@ class DescopeSessionManager {
 
   void _notifyTokens(DescopeSession session) {
     for (final listener in List<DescopeSessionManagerListener>.from(_listeners)) {
-      try {
-        listener.onUpdateTokens(session);
-      } catch (exception, stack) {
-        FlutterError.reportError(FlutterErrorDetails(
-          exception: exception,
-          stack: stack,
-          library: 'descope_flutter',
-          context: ErrorDescription('while notifying DescopeSessionManagerListener.onUpdateTokens'),
-        ));
-      }
+      listener.onUpdateTokens(session);
     }
   }
 
   void _notifyUser(DescopeSession session) {
     for (final listener in List<DescopeSessionManagerListener>.from(_listeners)) {
-      try {
-        listener.onUpdateUser(session);
-      } catch (exception, stack) {
-        FlutterError.reportError(FlutterErrorDetails(
-          exception: exception,
-          stack: stack,
-          library: 'descope_flutter',
-          context: ErrorDescription('while notifying DescopeSessionManagerListener.onUpdateUser'),
-        ));
-      }
+      listener.onUpdateUser(session);
     }
   }
 }

--- a/lib/src/session/manager.dart
+++ b/lib/src/session/manager.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '/src/types/responses.dart';
 import '/src/types/user.dart';
 import 'lifecycle.dart';
@@ -242,13 +244,31 @@ class DescopeSessionManager {
 
   void _notifyTokens(DescopeSession session) {
     for (final listener in List<DescopeSessionManagerListener>.from(_listeners)) {
-      listener.onUpdateTokens(session);
+      try {
+        listener.onUpdateTokens(session);
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'descope_flutter',
+          context: ErrorDescription('while notifying DescopeSessionManagerListener.onUpdateTokens'),
+        ));
+      }
     }
   }
 
   void _notifyUser(DescopeSession session) {
     for (final listener in List<DescopeSessionManagerListener>.from(_listeners)) {
-      listener.onUpdateUser(session);
+      try {
+        listener.onUpdateUser(session);
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'descope_flutter',
+          context: ErrorDescription('while notifying DescopeSessionManagerListener.onUpdateUser'),
+        ));
+      }
     }
   }
 }

--- a/lib/src/types/user.dart
+++ b/lib/src/types/user.dart
@@ -125,11 +125,17 @@ class DescopeUser {
         other.isVerifiedPhone == isVerifiedPhone &&
         other.givenName == givenName &&
         other.middleName == middleName &&
-        other.familyName == familyName;
+        other.familyName == familyName &&
+        other.hasPassword == hasPassword &&
+        other.status == status &&
+        listEquals(other.roleNames, roleNames) &&
+        listEquals(other.ssoAppIds, ssoAppIds) &&
+        listEquals(other.oauthProviders, oauthProviders) &&
+        mapEquals(other.customAttributes, customAttributes);
   }
 
   @override
   int get hashCode {
-    return Object.hash(userId, loginIds, createdAt, name, picture, email, isVerifiedEmail, phone, isVerifiedPhone, givenName, middleName, familyName);
+    return Object.hash(userId, loginIds, createdAt, name, picture, email, isVerifiedEmail, phone, isVerifiedPhone, givenName, middleName, familyName, hasPassword, status, roleNames, ssoAppIds, oauthProviders, customAttributes);
   }
 }

--- a/test/session_manager_listener_test.dart
+++ b/test/session_manager_listener_test.dart
@@ -1,0 +1,163 @@
+import 'package:descope/descope.dart';
+import 'package:descope/src/session/token.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _RecordingListener implements DescopeSessionManagerListener {
+  final List<String> tokenEvents = [];
+  final List<String> userEvents = [];
+
+  @override
+  void onUpdateTokens(DescopeSession session) {
+    tokenEvents.add(session.sessionJwt);
+  }
+
+  @override
+  void onUpdateUser(DescopeSession session) {
+    userEvents.add(session.user.userId);
+  }
+}
+
+class _MemoryStorage implements DescopeSessionStorage {
+  DescopeSession? saved;
+  int saveCount = 0;
+
+  @override
+  Future<DescopeSession?> loadSession() async => saved;
+
+  @override
+  Future<void> removeSession() async {
+    saved = null;
+  }
+
+  @override
+  Future<void> saveSession(DescopeSession session) async {
+    saved = session;
+    saveCount++;
+  }
+}
+
+class _NoopLifecycle implements DescopeSessionLifecycle {
+  @override
+  DescopeSession? session;
+
+  @override
+  void Function()? onRefresh;
+
+  @override
+  Future<void> refreshSessionIfNeeded() async {}
+}
+
+// Three distinct JWT strings sharing a valid header.payload (lifted from
+// jwt_test.dart) with different signature suffixes, so Token.decode succeeds
+// and the manager's string comparison treats them as distinct.
+const _jwtHeaderPayload =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikdvb2dseSBNY0ZsdXR0ZXIiLCJpYXQiOjE1MTYyMzkwMjIsImlzcyI6Imh0dHBzOi8vZGVzY29wZS5jb20vYmxhL1AxMjMiLCJleHAiOjE2MDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0';
+const _jwtA = '$_jwtHeaderPayload.sigA';
+const _jwtB = '$_jwtHeaderPayload.sigB';
+const _jwtC = '$_jwtHeaderPayload.sigC';
+
+DescopeUser _user(String id) => DescopeUser(
+      id,
+      const ['someone@example.com'],
+      0,
+      null,
+      null,
+      'someone@example.com',
+      true,
+      null,
+      false,
+      const {},
+      null,
+      null,
+      null,
+      false,
+      'enabled',
+      const [],
+      const [],
+      const [],
+    );
+
+DescopeSession _session({String session = _jwtA, String refresh = _jwtB, String userId = 'u1'}) {
+  return DescopeSession.fromJwt(session, refresh, _user(userId));
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  group('DescopeSessionManager listeners', () {
+    late _MemoryStorage storage;
+    late _NoopLifecycle lifecycle;
+    late DescopeSessionManager manager;
+    late _RecordingListener listener;
+
+    setUp(() {
+      storage = _MemoryStorage();
+      lifecycle = _NoopLifecycle();
+      manager = DescopeSessionManager(storage, lifecycle);
+      listener = _RecordingListener();
+      manager.addListener(listener);
+    });
+
+    test('manageSession fires token and user events on first set', () {
+      final session = _session();
+      manager.manageSession(session);
+      expect(listener.tokenEvents, [session.sessionJwt]);
+      expect(listener.userEvents, [session.user.userId]);
+    });
+
+    test('manageSession with identical jwts and user does not fire events', () {
+      final session = _session();
+      manager.manageSession(session);
+      listener.tokenEvents.clear();
+      listener.userEvents.clear();
+
+      manager.manageSession(_session());
+      expect(listener.tokenEvents, isEmpty);
+      expect(listener.userEvents, isEmpty);
+    });
+
+    test('manageSession with different jwts fires only tokens event', () {
+      final initial = _session();
+      manager.manageSession(initial);
+      listener.tokenEvents.clear();
+      listener.userEvents.clear();
+
+      final rotated = DescopeSession.fromJwt(_jwtC, _jwtB, initial.user);
+      manager.manageSession(rotated);
+      expect(listener.tokenEvents, [_jwtC]);
+      expect(listener.userEvents, isEmpty);
+    });
+
+    test('updateTokens fires onUpdateTokens', () {
+      manager.manageSession(_session());
+      listener.tokenEvents.clear();
+
+      final newSessionToken = Token.decode(_jwtC);
+      final newRefreshToken = Token.decode(_jwtB);
+      manager.updateTokens(RefreshResponse(newSessionToken, newRefreshToken));
+      expect(listener.tokenEvents, [_jwtC]);
+    });
+
+    test('updateUser fires onUpdateUser', () {
+      manager.manageSession(_session());
+      listener.userEvents.clear();
+
+      manager.updateUser(_user('u2'));
+      expect(listener.userEvents, ['u2']);
+    });
+
+    test('removeListener stops further events', () {
+      manager.manageSession(_session());
+      manager.removeListener(listener);
+      listener.tokenEvents.clear();
+      listener.userEvents.clear();
+
+      manager.updateTokens(RefreshResponse(Token.decode(_jwtC), Token.decode(_jwtB)));
+      manager.updateUser(_user('u9'));
+      expect(listener.tokenEvents, isEmpty);
+      expect(listener.userEvents, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/5521

## Description
- `DescopeFlowView` now automatically runs as the active user when a `DescopeSessionManager` is managing a session, by passing the session JWTs to the native flow's `sessionProvider`
- Add `DescopeSessionManagerListener` interface plus `addListener` / `removeListener` on `DescopeSessionManager`, matching the `Listener` API in `descope-kotlin` and `DescopeSessionManagerDelegate` in `descope-swift`
- `DescopeFlowView` registers as a listener and pushes refreshed tokens to the native bridge through a new `updateSession` method-channel call, so the flow's `sessionProvider` always returns the newest session even after refresh-token rotation
- Add `DescopeFlowConfig.sdk` to let callers run the flow against a non-global `DescopeSdk` instance
- Mirrors descope/descope-react-native#165

## Must
- [x] Tests
- [x] Documentation