### PR TITLE
feat: bump native SDKs and surface externalToken from flows

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ android {
         implementation "androidx.browser:browser:1.8.0"
         implementation "androidx.security:security-crypto:1.1.0"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
-        implementation "com.descope:descope-kotlin:0.18.0"
+        implementation "com.descope:descope-kotlin:0.19.1"
     }
 
     testOptions {

--- a/android/src/main/kotlin/com/descope/flutter/DescopeFlowViewWrapper.kt
+++ b/android/src/main/kotlin/com/descope/flutter/DescopeFlowViewWrapper.kt
@@ -144,12 +144,14 @@ fun Any?.toDescopeFlow(): DescopeFlow {
 
 // Utilities
 
-private fun AuthenticationResponse.toMap(): Map<String, Any> = mutableMapOf(
+private fun AuthenticationResponse.toMap(): Map<String, Any> = mutableMapOf<String, Any>(
     "sessionJwt" to sessionToken.jwt,
     "refreshJwt" to refreshToken.jwt,
     "user" to user.toMap(),
     "firstSeen" to isFirstAuthentication
-)
+).apply {
+    externalToken?.let { put("externalToken", it) }
+}
 
 private fun DescopeUser.toMap() = mutableMapOf<String, Any>().apply {
     put("userId", userId)

--- a/ios/descope/Sources/descope/descope-swift-sdk/DescopeKit.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/DescopeKit.swift
@@ -92,6 +92,9 @@ public extension Descope {
     /// Provides functions for authentication with enchanted links.
     static var enchantedLink: DescopeEnchantedLink { sdk.enchantedLink }
     
+    /// Provides functions for authentication with push notifications.
+    static var push: DescopePush { sdk.push }
+    
     /// Provides functions for authentication with OAuth.
     static var oauth: DescopeOAuth { sdk.oauth }
     

--- a/ios/descope/Sources/descope/descope-swift-sdk/flows/FlowBridge.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/flows/FlowBridge.swift
@@ -224,7 +224,10 @@ extension FlowBridge {
             }
         case .failure:
             logger.error("Bridge received failure event", message.body)
-            if let dict = message.body as? [String: Any], let error = DescopeError(errorResponse: dict) {
+            if let dict = message.body as? [String: Any], var error = DescopeError(errorResponse: dict) {
+                if error.code == "E102122" { // convert server-side flow aborted error to client-side flow cancelled error
+                    error = DescopeError.flowCancelled.with(message: error.message)
+                }
                 delegate?.bridgeDidFailAuthentication(self, error: error)
             } else if let reason = message.body as? String, !reason.isEmpty {
                 delegate?.bridgeDidFailAuthentication(self, error: DescopeError.flowFailed.with(message: reason))
@@ -286,7 +289,7 @@ extension FlowBridge: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
-        var error = error as NSError
+        let error = error as NSError
         
         // Ignore navigation cancellations that are an expected part of the navigation lifecycle
         // due to, e.g., redirects,
@@ -367,7 +370,7 @@ private extension FlowBridgeRequest {
             guard let start = payload["start"] as? [String: Any] else { return nil }
             guard let clientId = start["clientId"] as? String, let stateId = start["stateId"] as? String, let nonce = start["nonce"] as? String, let implicit = start["implicit"] as? Bool else { return nil }
             self = .oauthNative(clientId: clientId, stateId: stateId, nonce: nonce, implicit: implicit)
-        case "oauthWeb", "sso":
+        case "oauthWeb", "sso", "externalAuth":
             guard let startString = payload["startUrl"] as? String, let startURL = URL(string: startString) else { return nil }
             var finishURL: URL?
             if let str = payload["finishUrl"] as? String, !str.isEmpty, let url = URL(string: str) {
@@ -446,6 +449,7 @@ private struct FlowNativeOptions: Encodable {
     var oauthProvider = ""
     var oauthRedirect = WebAuth.redirectURL
     var ssoRedirect = WebAuth.redirectURL
+    var externalAuthRedirect = WebAuth.redirectURL
     var magicLinkRedirect = ""
 
     var payload: String {
@@ -501,7 +505,7 @@ window.descopeBridge = {
         platformVersion: \(SystemInfo.osVersion.javaScriptLiteralString()),
         appName: \(SystemInfo.appName?.javaScriptLiteralString() ?? "''"),
         appVersion: \(SystemInfo.appVersion?.javaScriptLiteralString() ?? "''"), 
-        device: \(SystemInfo.device?.javaScriptLiteralString() ?? "''"),
+        device: \(SystemInfo.device.javaScriptLiteralString()),
         webauthn: true,
     },
 

--- a/ios/descope/Sources/descope/descope-swift-sdk/flows/FlowCoordinator.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/flows/FlowCoordinator.swift
@@ -61,7 +61,7 @@ public class DescopeFlowCoordinator {
     /// The flow that's currently running in the ``DescopeFlowCoordinator``.
     public private(set) var flow: DescopeFlow? {
         didSet {
-            sdk.resume = resumeClosure
+            sdk.resume = makeResumeClosure(self)
             logger = sdk.config.logger
             bridge.flow = flow
             bridge.logger = logger
@@ -232,7 +232,7 @@ public class DescopeFlowCoordinator {
 
     // Resume
 
-    private func resume(_ url: URL) -> Bool {
+    func resume(_ url: URL) -> Bool {
         guard state == .ready else {
             logger.debug("Ignoring resume URL", state)
             return false
@@ -240,10 +240,6 @@ public class DescopeFlowCoordinator {
         logger.info("Received URL for resuming flow", url)
         sendResponse(.magicLink(url: url.absoluteString))
         return true
-    }
-
-    private lazy var resumeClosure: DescopeSDK.ResumeClosure = { [weak self] url in
-        return self?.resume(url) ?? false
     }
 
     // Events
@@ -447,5 +443,11 @@ private class WebViewLayoutObserver: NSObject {
                 handler()
             }
         })
+    }
+}
+
+private func makeResumeClosure(_ coordinator: DescopeFlowCoordinator) -> DescopeSDK.ResumeClosure {
+    return { [weak coordinator] url in
+        return coordinator?.resume(url) ?? false
     }
 }

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/http/DescopeClient.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/http/DescopeClient.swift
@@ -297,6 +297,23 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         ])
     }
     
+    // MARK: - Push
+    
+    func pushEnrollDevice(provider: String, token: String, device: String, refreshJwt: String) async throws(DescopeError) {
+        try await post("auth/push/update", headers: authorization(with: refreshJwt), body: [
+            "provider": provider,
+            "token": token,
+            "device": device,
+        ])
+    }
+    
+    func pushSignInFinish(transactionId: String, approved: Bool, refreshJwt: String) async throws(DescopeError) {
+        try await post("auth/push/signin/finish", headers: authorization(with: refreshJwt), body: [
+            "transactionId": transactionId,
+            "result": approved ? "approved" : "denied",
+        ])
+    }
+    
     // MARK: - OAuth
     
     struct OAuthResponse: JSONResponse {
@@ -428,7 +445,10 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         var user: UserResponse?
         var firstSeen: Bool
         var cookieDomain: String?
-        
+        var cookieName: String?
+        var sessionCookieName: String?
+        var externalToken: String?
+
         mutating func setValues(from data: Data, response: HTTPURLResponse) throws {
             guard let url = response.url, let fields = response.allHeaderFields as? [String: String] else { return }
             let cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
@@ -444,10 +464,12 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
                 user?.setCustomAttributes(from: dict)
             }
             if sessionJwt == nil || sessionJwt == "" {
-                sessionJwt = findTokenCookie(named: sessionCookieName, in: cookies)
+                let name = (sessionCookieName == "" ? nil : sessionCookieName) ?? DescopeClient.sessionCookieName
+                sessionJwt = findTokenCookie(named: name, in: cookies)
             }
             if refreshJwt == nil || refreshJwt == "" {
-                refreshJwt = findTokenCookie(named: refreshCookieName ?? DescopeClient.refreshCookieName, in: cookies)
+                let name = (cookieName == "" ? nil : cookieName) ?? refreshCookieName ?? DescopeClient.refreshCookieName
+                refreshJwt = findTokenCookie(named: name, in: cookies)
             }
         }
     }
@@ -555,6 +577,7 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
             "x-descope-sdk-version": DescopeSDK.version,
             "x-descope-platform-name": SystemInfo.osName,
             "x-descope-platform-version": SystemInfo.osVersion,
+            "x-descope-device": SystemInfo.device,
             "x-descope-project-id": config.projectId,
         ]
         if let appName = SystemInfo.appName, !appName.isEmpty {
@@ -562,9 +585,6 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         }
         if let appVersion = SystemInfo.appVersion, !appVersion.isEmpty {
             headers["x-descope-app-version"] = appVersion
-        }
-        if let device = SystemInfo.device, !device.isEmpty {
-            headers["x-descope-device"] = device
         }
         return headers
     }

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/http/HTTPClient.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/http/HTTPClient.swift
@@ -85,20 +85,22 @@ class HTTPClient {
         }
 
         if let error = DescopeError(httpStatusCode: response.statusCode) {
+            let cfray = response.value(forHTTPHeaderField: "cf-ray")
+            let trace = cfray.map { " [CF-Ray: \($0)]" } ?? ""
             if let responseError = errorForResponseData(data) {
                 if logger.isUnsafeEnabled {
-                    logger.error("Network call failed with server error", request.url, responseError)
+                    logger.error("Network call failed with server error\(trace)", request.url, responseError)
                 } else {
-                    logger.error("Network call to \(route) failed with \(responseError.code) server error")
+                    logger.error("Network call to \(route) failed with \(responseError.code) server error\(trace)")
                 }
-                throw responseError
+                throw responseError.with(traceId: cfray)
             }
             if logger.isUnsafeEnabled {
-                logger.error("Network call failed with \(response.statusCode) http error", request.url, error)
+                logger.error("Network call failed with \(response.statusCode) http error\(trace)", request.url, error)
             } else {
-                logger.error("Network call to \(route) failed with \(response.statusCode) http error")
+                logger.error("Network call to \(route) failed with \(response.statusCode) http error\(trace)")
             }
-            throw error
+            throw error.with(traceId: cfray)
         }
         
         if logger.isUnsafeEnabled {

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/http/SystemInfo.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/http/SystemInfo.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(iOS)
+import UIKit
+#endif
 
 enum SystemInfo {
     static let osName = makeOSName()
@@ -31,26 +34,28 @@ private func makeAppVersion() -> String? {
     return "\(version).\(build)"
 }
 
-private func makeDevice() -> String? {
+private func makeDevice() -> String {
     #if targetEnvironment(simulator)
     return "Simulator"
     #else
     // use different ioctl name according to os
     #if os(iOS)
     let ioctl = "hw.machine"
+    let fallback = UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone"
     #else
     let ioctl = "hw.model"
+    let fallback = "Mac"
     #endif
 
     // get the size of the value first
     var size = 0
-    guard sysctlbyname(ioctl, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+    guard sysctlbyname(ioctl, nil, &size, nil, 0) == 0, size > 0 else { return fallback }
 
     // create an appropriately sized array and call again to retrieve the value
     var chars = [CChar](repeating: 0, count: size)
-    guard sysctlbyname(ioctl, &chars, &size, nil, 0) == 0 else { return nil }
+    guard sysctlbyname(ioctl, &chars, &size, nil, 0) == 0 else { return fallback }
 
     // the device model, e.g., "MacBookPro18,4" or "iPhone17,2"
-    return String(utf8String: chars)
+    return String(utf8String: chars) ?? fallback
     #endif
 }

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/others/Internal.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/others/Internal.swift
@@ -6,16 +6,21 @@ extension DescopeSDK {
 }
 
 extension DescopeError {
-    func with(desc: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
-    }
-    
-    func with(message: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
-    }
-    
-    func with(cause: Error) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
+    func with(desc: String? = nil, message: String? = nil, cause: Error? = nil, traceId: String? = nil) -> DescopeError {
+        var error = self
+        if let desc, !desc.isEmpty {
+            error.desc = desc
+        }
+        if let message, !message.isEmpty {
+            error.message = message
+        }
+        if let cause {
+            error.cause = cause
+        }
+        if let traceId, !traceId.isEmpty {
+            error.traceId = traceId
+        }
+        return error
     }
 }
 
@@ -224,6 +229,7 @@ extension AuthenticationResponse: Codable {
         case refreshToken = "refreshJwt"
         case user
         case isFirstAuthentication
+        case externalToken
     }
 
     public init(from decoder: Decoder) throws {
@@ -232,6 +238,7 @@ extension AuthenticationResponse: Codable {
         refreshToken = try Token(jwt: values.decode(String.self, forKey: .refreshToken))
         user = try values.decode(DescopeUser.self, forKey: .user)
         isFirstAuthentication = try values.decode(Bool.self, forKey: .isFirstAuthentication)
+        externalToken = try values.decodeIfPresent(String.self, forKey: .externalToken)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -240,6 +247,7 @@ extension AuthenticationResponse: Codable {
         try values.encode(refreshToken.jwt, forKey: .refreshToken)
         try values.encode(user, forKey: .user)
         try values.encode(isFirstAuthentication, forKey: .isFirstAuthentication)
+        try values.encodeIfPresent(externalToken, forKey: .externalToken)
     }
 }
 

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/others/WebAuth.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/others/WebAuth.swift
@@ -14,9 +14,12 @@ enum WebAuth {
 
 @MainActor
 private func presentWebAuthentication(url: URL, accessSharedUserData: Bool, logger: DescopeLogger?) async throws(DescopeError) -> URL? {
-    let contextProvider = DefaultPresentationContextProvider()
-    var cancellation: @MainActor () -> Void = {}
+    // create a constant class instance to wrap the cancellation closure because
+    // the onCancel closure below is nonisolated and can be called concurrently
+    // with the main async closure that sets its value
+    let cancellation = CancellationWrapper()
 
+    let contextProvider = DefaultPresentationContextProvider()
     #if os(iOS) && canImport(React)
     await contextProvider.waitKeyWindow()
     #endif
@@ -31,17 +34,18 @@ private func presentWebAuthentication(url: URL, accessSharedUserData: Bool, logg
                 }
             }
 
-            cancellation = { @MainActor [weak session] in
+            cancellation.closure = { @MainActor [weak session] in
                 logger.info("Web authentication cancelled programmatically")
                 session?.cancel()
             }
 
             session.presentationContextProvider = contextProvider
+            session.prefersEphemeralWebBrowserSession = !accessSharedUserData
             session.start()
         }
     } onCancel: {
         Task { @MainActor in
-            cancellation()
+            cancellation.closure()
         }
     }
 
@@ -62,6 +66,11 @@ private func presentWebAuthentication(url: URL, accessSharedUserData: Bool, logg
         logger.debug("Processing OAuth web authentication", callbackURL)
         return callbackURL
     }
+}
+
+@MainActor
+private final class CancellationWrapper {
+    var closure: @MainActor () -> Void = {}
 }
 
 private func parseExchangeCode(from callbackURL: URL?) throws(DescopeError) -> String {

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Push.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Push.swift
@@ -1,0 +1,17 @@
+
+final class Push: DescopePush {
+    let client: DescopeClient
+    
+    init(client: DescopeClient) {
+        self.client = client
+    }
+    
+    func enroll(token: String, development: Bool, refreshJwt: String) async throws(DescopeError) {
+        let provider = development ? "apndev" : "apn"
+        try await client.pushEnrollDevice(provider: provider, token: token, device: SystemInfo.device, refreshJwt: refreshJwt)
+    }
+    
+    func finish(transactionId: String, approved: Bool, refreshJwt: String) async throws(DescopeError) {
+        try await client.pushSignInFinish(transactionId: transactionId, approved: approved, refreshJwt: refreshJwt)
+    }
+}

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Shared.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Shared.swift
@@ -73,7 +73,7 @@ extension DescopeClient.JWTResponse {
         guard let sessionJwt, !sessionJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing session JWT") }
         guard let refreshJwt, !refreshJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing refresh JWT") }
         guard let user else { throw DescopeError.decodeError.with(message: "Missing user details") }
-        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen)
+        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen, externalToken: externalToken)
     }
 }
 

--- a/ios/descope/Sources/descope/descope-swift-sdk/sdk/Callbacks.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/sdk/Callbacks.swift
@@ -967,6 +967,28 @@ public extension DescopePassword {
     }
 }
 
+public extension DescopePush {
+    func enroll(token: String, development: Bool, refreshJwt: String, completion: @escaping @Sendable (Result<Void, DescopeError>) -> Void) {
+        Task {
+            do throws(DescopeError) {
+                completion(.success(try await enroll(token: token, development: development, refreshJwt: refreshJwt)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func finish(transactionId: String, approved: Bool, refreshJwt: String, completion: @escaping @Sendable (Result<Void, DescopeError>) -> Void) {
+        Task {
+            do throws(DescopeError) {
+                completion(.success(try await finish(transactionId: transactionId, approved: approved, refreshJwt: refreshJwt)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
 public extension DescopeSSO {
     /// Starts an SSO redirect chain to authenticate a user.
     /// 

--- a/ios/descope/Sources/descope/descope-swift-sdk/sdk/Routes.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/sdk/Routes.swift
@@ -479,6 +479,33 @@ public protocol DescopeEnchantedLink: Sendable {
 }
 
 
+/// Authenticate users using push notifications.
+///
+/// The push notification authentication works by registering the user's device
+/// via APNs (Apple Push Notification service) and then completing authentication
+/// transactions by approving or denying them.
+public protocol DescopePush: Sendable {
+    /// Registers an APNs device token for push authentication.
+    ///
+    /// The user must have an active ``DescopeSession`` whose `refreshJwt` should be
+    /// passed as a parameter to this function.
+    ///
+    /// - Parameters:
+    ///   - token: The APNs device token to register.
+    ///   - development: Whether the token is for the development or production APNs environment.
+    ///   - refreshJwt: The `refreshJwt` from an active ``DescopeSession``.
+    func enroll(token: String, development: Bool, refreshJwt: String) async throws(DescopeError)
+
+    /// Completes a push authentication transaction by approving or denying it.
+    ///
+    /// - Parameters:
+    ///   - transactionId: The ID of the push authentication transaction.
+    ///   - approved: Whether the authentication request is approved or denied.
+    ///   - refreshJwt: The `refreshJwt` from an active ``DescopeSession``.
+    func finish(transactionId: String, approved: Bool, refreshJwt: String) async throws(DescopeError)
+}
+
+
 /// Authenticate a user using an OAuth provider.
 ///
 /// Use the Descope console to configure which authentication provider you'd like to support.

--- a/ios/descope/Sources/descope/descope-swift-sdk/sdk/SDK.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/sdk/SDK.swift
@@ -30,6 +30,9 @@ public class DescopeSDK {
     /// Provides functions for authentication with enchanted links.
     public let enchantedLink: DescopeEnchantedLink
     
+    /// Provides functions for authentication with push notifications.
+    public let push: DescopePush
+    
     /// Provides functions for authentication with OAuth.
     public let oauth: DescopeOAuth
     
@@ -124,6 +127,7 @@ public class DescopeSDK {
         self.password = Password(client: client)
         self.magicLink = MagicLink(client: client)
         self.enchantedLink = EnchantedLink(client: client)
+        self.push = Push(client: client)
         self.oauth = OAuth(client: client)
         self.sso = SSO(client: client)
         self.accessKey = AccessKey(client: client)
@@ -143,7 +147,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.10.5"
+    static let version = "0.11.1"
 }
 
 // Internal

--- a/ios/descope/Sources/descope/descope-swift-sdk/types/Error.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/types/Error.swift
@@ -63,6 +63,16 @@ public struct DescopeError: Error {
     /// call. When a ``DescopeError/passkeyFailed`` error is thrown the ``cause`` property
     /// will often contain an instance of AuthorizationError.
     public var cause: Error?
+
+    /// An optional trace identifier for a failed network request.
+    ///
+    /// When the Descope server is accessed through its CDN (the default), this holds the
+    /// value of the `CF-Ray` response header of the failed request. You can log this value
+    /// or send it to Descope support to help trace and diagnose server errors.
+    ///
+    /// This is `nil` for errors that aren't associated with a server response, such as
+    /// ``DescopeError/networkError``, or when the response didn't include the header.
+    public var traceId: String?
 }
 
 /// A list of common ``DescopeError`` values that can be thrown by the Descope SDK.
@@ -142,6 +152,9 @@ extension DescopeError: CustomStringConvertible {
         }
         if let cause {
             str += ", cause: {\(cause)}"
+        }
+        if let traceId {
+            str += ", traceId: \"\(traceId)\""
         }
         str += ")"
         return str

--- a/ios/descope/Sources/descope/descope-swift-sdk/types/Responses.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/types/Responses.swift
@@ -10,6 +10,7 @@ public struct AuthenticationResponse: Sendable {
     public var refreshToken: DescopeToken
     public var user: DescopeUser
     public var isFirstAuthentication: Bool
+    public var externalToken: String?
 }
 
 /// Returned from the ``DescopeAuth/refreshSession(refreshJwt:)`` call.

--- a/scripts/update-kotlin-sdk.sh
+++ b/scripts/update-kotlin-sdk.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="descope/descope-kotlin"
+GRADLE_FILE="android/build.gradle"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+# Resolve version: argument or latest release
+if [ -n "${1:-}" ]; then
+  VERSION="$1"
+else
+  VERSION=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
+fi
+
+# The Kotlin SDK is consumed as a Maven dependency, not vendored as source,
+# so bump the version pinned in the Gradle build file.
+CURRENT=$(grep -oE 'com.descope:descope-kotlin:[0-9]+\.[0-9]+\.[0-9]+' "$GRADLE_FILE" | head -1 | cut -d: -f3)
+
+if [ -z "$CURRENT" ]; then
+  echo "Could not find com.descope:descope-kotlin dependency in $GRADLE_FILE" >&2
+  exit 1
+fi
+
+sed -i '' "s/com.descope:descope-kotlin:$CURRENT/com.descope:descope-kotlin:$VERSION/" "$GRADLE_FILE"
+
+echo "descope-kotlin: $CURRENT -> $VERSION"
+echo "Updated: $GRADLE_FILE"

--- a/scripts/update-swift-sdk.sh
+++ b/scripts/update-swift-sdk.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="descope/descope-swift"
+SDK_SRC="src"
+TARGET_DIR="ios/descope/Sources/descope/descope-swift-sdk"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+if [ -n "${1:-}" ]; then
+  VERSION="$1"
+else
+  VERSION=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name')
+fi
+
+echo "Fetching descope-swift $VERSION"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+gh api "repos/$REPO/tarball/$VERSION" > "$TMPDIR/sdk.tar.gz"
+tar -xzf "$TMPDIR/sdk.tar.gz" -C "$TMPDIR" --strip-components=1
+
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+for entry in "$TMPDIR/$SDK_SRC"/*; do
+  name=$(basename "$entry")
+  [ "$name" = "docs" ] && continue
+  cp -r "$entry" "$TARGET_DIR/"
+done
+
+echo "SDK version: $VERSION"
+echo "Sources copied to: $TARGET_DIR"


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16830

## Description
- Update the `descope-swift` SDK to `0.11.1` and the `descope-kotlin` dependency to `0.19.1` to receive support for:
  - `externalToken` on the flow `AuthenticationResponse`
  - Passkey and oauth cancellation control

## Must
- [x] Tests
- [ ] Documentation (if applicable)