### PR TITLE
feat: surface flowOutput from flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,19 @@ class _NativeFlowScreenState extends State<NativeFlowScreen> {
 }
 ```
 
+### Flow Output
+
+Flows can return custom data by setting a flow output in the Descope console. When present,
+it's available on the `flowOutput` field of the `AuthenticationResponse` the flow finishes with.
+The map is empty for authentications that don't originate from a flow.
+
+```dart
+onSuccess: (AuthenticationResponse res) {
+  final orgId = res.flowOutput['organizationId'] as String?;
+  // ...
+},
+```
+
 ## Authentication Methods
 
 We can authenticate users by using any combination of the authentication methods

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ android {
         implementation "androidx.browser:browser:1.8.0"
         implementation "androidx.security:security-crypto:1.1.0"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
-        implementation "com.descope:descope-kotlin:0.19.1"
+        implementation "com.descope:descope-kotlin:0.20.0"
     }
 
     testOptions {

--- a/android/src/main/kotlin/com/descope/flutter/DescopeFlowViewWrapper.kt
+++ b/android/src/main/kotlin/com/descope/flutter/DescopeFlowViewWrapper.kt
@@ -151,6 +151,7 @@ private fun AuthenticationResponse.toMap(): Map<String, Any> = mutableMapOf<Stri
     "firstSeen" to isFirstAuthentication
 ).apply {
     externalToken?.let { put("externalToken", it) }
+    if (flowOutput.isNotEmpty()) put("flowOutput", flowOutput)
 }
 
 private fun DescopeUser.toMap() = mutableMapOf<String, Any>().apply {

--- a/ios/descope/Sources/descope/FlutterDescopeFlowView.swift
+++ b/ios/descope/Sources/descope/FlutterDescopeFlowView.swift
@@ -164,6 +164,13 @@ class DescopeFlowViewWrapper: DescopeFlowView, DescopeFlowViewDelegate {
             user["customAttributes"] = [:]
         }
 
+        // flow output is serialized as a JSON string, and is omitted when empty
+        if let value = dict["flowOutput"] as? String, let json = try? JSONSerialization.jsonObject(with: Data(value.utf8)) {
+            dict["flowOutput"] = json as? [String: Any] ?? [:]
+        } else {
+            dict.removeValue(forKey: "flowOutput")
+        }
+
         dict["user"] = user
         self.channel?.invokeMethod("onSuccess", arguments: dict)
     }

--- a/ios/descope/Sources/descope/descope-swift-sdk/flows/FlowCoordinator.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/flows/FlowCoordinator.swift
@@ -307,25 +307,40 @@ public class DescopeFlowCoordinator {
     }
 
     // Authentication
-
-    private func handleAuthentication(_ data: Data) {
-        logger.info("Finishing flow authentication")
-        Task {
-            guard let authResponse = await parseAuthentication(data) else { return }
-            handleSuccess(authResponse)
+    
+    private func handleData(_ data: Data?) async {
+        let jwtResponse = await parseJWTResponse(data)
+        if let jwtResponse {
+            do {
+                let authResponse = try jwtResponse.convert()
+                logger.debug("Finishing flow with an authentication response", data)
+                return handleSuccess(authResponse)
+            } catch {
+                logger.debug("Finishing flow with a partial authentication response")
+            }
         }
+
+        if let session = flow?.providedSession {
+            if jwtResponse == nil {
+                logger.info("Finishing flow authentication without an authentication response")
+            }
+            return handleSuccess(AuthenticationResponse(sessionToken: session.sessionToken, refreshToken: session.refreshToken, user: session.user, isFirstAuthentication: false, flowOutput: jwtResponse?.flowOutput ?? [:]))
+        }
+        
+        logger.error("Couldn't find session to finish flow", flow?.sessionProvider == nil ? "nil provider" : "custom provider")
+        handleError(DescopeError.flowFailed.with(message: "No valid authentication tokens found"))
     }
 
-    private func parseAuthentication(_ data: Data) async -> AuthenticationResponse? {
+    private func parseJWTResponse(_ data: Data?) async -> DescopeClient.JWTResponse? {
+        guard let data, let webView else { return nil }
         do {
-            guard let webView else { return nil }
             var jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
             let cookies = await webView.configuration.websiteDataStore.httpCookieStore.cookies(for: jwtResponse.cookieDomain, at: webView.url)
             try jwtResponse.setValues(from: data, cookies: cookies, refreshCookieName: bridge.attributes.refreshCookieName)
-            return try jwtResponse.convert()
+            return jwtResponse
         } catch {
+            // should never happen because all JWTResponse fields are optional
             logger.error("Unexpected error parsing authentication response", error, String(bytes: data, encoding: .utf8))
-            handleError(DescopeError.flowFailed.with(message: "No valid authentication response found"))
             return nil
         }
     }
@@ -401,13 +416,8 @@ extension DescopeFlowCoordinator: FlowBridgeDelegate {
     }
 
     func bridgeDidFinish(_ bridge: FlowBridge, data: Data?) {
-        if let data {
-            handleAuthentication(data)
-        } else if let session = flow?.providedSession {
-            handleSuccess(AuthenticationResponse(sessionToken: session.sessionToken, refreshToken: session.refreshToken, user: session.user, isFirstAuthentication: false))
-        } else {
-            logger.error("Couldn't find session to finish flow", flow?.sessionProvider == nil ? "nil provider" : "custom provider")
-            handleError(DescopeError.flowFailed.with(message: "No valid authentication tokens found"))
+        Task { @MainActor in
+            await handleData(data)
         }
     }
 }

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/http/DescopeClient.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/http/DescopeClient.swift
@@ -443,11 +443,18 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         var sessionJwt: String?
         var refreshJwt: String?
         var user: UserResponse?
-        var firstSeen: Bool
+        var firstSeen: Bool?
         var cookieDomain: String?
         var cookieName: String?
         var sessionCookieName: String?
         var externalToken: String?
+        var flowOutput: [String: Any]?
+
+        // we enumerate the properties explicitly to skip over flowOutput, whose
+        // arbitrary JSON object is populated separately in setValues below
+        enum CodingKeys: String, CodingKey {
+            case sessionJwt, refreshJwt, user, firstSeen, cookieDomain, cookieName, sessionCookieName, externalToken
+        }
 
         mutating func setValues(from data: Data, response: HTTPURLResponse) throws {
             guard let url = response.url, let fields = response.allHeaderFields as? [String: String] else { return }
@@ -462,6 +469,9 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
             if let dict = json["user"] as? [String: Any] {
                 user?.setCustomAttributes(from: dict)
+            }
+            if let output = json["flowOutput"] as? [String: Any], !output.isEmpty {
+                flowOutput = output
             }
             if sessionJwt == nil || sessionJwt == "" {
                 let name = (sessionCookieName == "" ? nil : sessionCookieName) ?? DescopeClient.sessionCookieName

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/others/Internal.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/others/Internal.swift
@@ -227,9 +227,10 @@ extension AuthenticationResponse: Codable {
     enum CodingKeys: String, CodingKey {
         case sessionToken = "sessionJwt"
         case refreshToken = "refreshJwt"
+        case externalToken
         case user
         case isFirstAuthentication
-        case externalToken
+        case flowOutput
     }
 
     public init(from decoder: Decoder) throws {
@@ -239,6 +240,11 @@ extension AuthenticationResponse: Codable {
         user = try values.decode(DescopeUser.self, forKey: .user)
         isFirstAuthentication = try values.decode(Bool.self, forKey: .isFirstAuthentication)
         externalToken = try values.decodeIfPresent(String.self, forKey: .externalToken)
+        if let value = try values.decodeIfPresent(String.self, forKey: .flowOutput) {
+            flowOutput = (try? JSONSerialization.jsonObject(with: Data(value.utf8))) as? [String: Any] ?? [:]
+        } else {
+            flowOutput = [:]
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -248,6 +254,11 @@ extension AuthenticationResponse: Codable {
         try values.encode(user, forKey: .user)
         try values.encode(isFirstAuthentication, forKey: .isFirstAuthentication)
         try values.encodeIfPresent(externalToken, forKey: .externalToken)
+        if !flowOutput.isEmpty, JSONSerialization.isValidJSONObject(flowOutput) {
+            let data = try JSONSerialization.data(withJSONObject: flowOutput)
+            let value = String(bytes: data, encoding: .utf8)
+            try values.encodeIfPresent(value, forKey: .flowOutput)
+        }
     }
 }
 

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Auth.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Auth.swift
@@ -21,7 +21,7 @@ final class Auth: DescopeAuth {
     func migrateSession(externalToken: String) async throws(DescopeError) -> AuthenticationResponse {
         let response: MigrateResponse = try await client.migrate(externalToken: externalToken).convert()
         let user = try await me(refreshJwt: response.refreshToken.jwt)
-        return AuthenticationResponse(sessionToken: response.sessionToken, refreshToken: response.refreshToken, user: user, isFirstAuthentication: false)
+        return AuthenticationResponse(sessionToken: response.sessionToken, refreshToken: response.refreshToken, user: user, isFirstAuthentication: false, flowOutput: [:])
     }
 
     func revokeSessions(_ revoke: RevokeType, refreshJwt: String) async throws(DescopeError) {

--- a/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Shared.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/internal/routes/Shared.swift
@@ -73,7 +73,7 @@ extension DescopeClient.JWTResponse {
         guard let sessionJwt, !sessionJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing session JWT") }
         guard let refreshJwt, !refreshJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing refresh JWT") }
         guard let user else { throw DescopeError.decodeError.with(message: "Missing user details") }
-        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen, externalToken: externalToken)
+        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), externalToken: externalToken, user: user.convert(), isFirstAuthentication: firstSeen ?? false, flowOutput: flowOutput ?? [:])
     }
 }
 

--- a/ios/descope/Sources/descope/descope-swift-sdk/sdk/SDK.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/sdk/SDK.swift
@@ -147,7 +147,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.11.1"
+    static let version = "0.11.2"
 }
 
 // Internal

--- a/ios/descope/Sources/descope/descope-swift-sdk/types/Responses.swift
+++ b/ios/descope/Sources/descope/descope-swift-sdk/types/Responses.swift
@@ -5,12 +5,13 @@ import UIKit
 #endif
 
 /// Returned from user authentication calls.
-public struct AuthenticationResponse: Sendable {
+public struct AuthenticationResponse: @unchecked Sendable {
     public var sessionToken: DescopeToken
     public var refreshToken: DescopeToken
+    public var externalToken: String?
     public var user: DescopeUser
     public var isFirstAuthentication: Bool
-    public var externalToken: String?
+    public var flowOutput: [String: Any]
 }
 
 /// Returned from the ``DescopeAuth/refreshSession(refreshJwt:)`` call.

--- a/lib/src/flow/descope_flow_view_native.dart
+++ b/lib/src/flow/descope_flow_view_native.dart
@@ -225,6 +225,7 @@ class _DescopeFlowViewState extends State<DescopeFlowView> implements DescopeSes
                   authenticationResponse.isFirstAuthentication,
                   activeUser,
                   authenticationResponse.externalToken,
+                  authenticationResponse.flowOutput,
                 );
               }
             }

--- a/lib/src/internal/http/http_client.dart
+++ b/lib/src/internal/http/http_client.dart
@@ -156,7 +156,7 @@ class _DefaultNetworkClient extends DescopeNetworkClient {
   Future<http.Response> sendRequest(http.Request request) async {
     final stream = await _client.send(request);
     try {
-      return http.Response.fromStream(stream);
+      return await http.Response.fromStream(stream);
     } catch (e) {
       throw InternalErrors.httpError.add(desc: invalidResponse);
     }

--- a/lib/src/internal/http/responses.dart
+++ b/lib/src/internal/http/responses.dart
@@ -15,8 +15,9 @@ class JWTServerResponse {
   UserResponse? user;
   bool firstSeen;
   String? externalToken;
+  Map<String, dynamic>? flowOutput;
 
-  JWTServerResponse(this.sessionJwt, this.refreshJwt, this.user, this.firstSeen, this.externalToken);
+  JWTServerResponse(this.sessionJwt, this.refreshJwt, this.user, this.firstSeen, this.externalToken, this.flowOutput);
   static var fromJson = _$JWTServerResponseFromJson;
   static var decoder = _parseHeaders(fromJson, (response, headers) {
     final cookies = _cookiesFromHeaders(headers);
@@ -52,6 +53,7 @@ class UserResponse {
   String status;
   List<String> roleNames;
   List<String> ssoAppIds;
+  @JsonKey(name: 'OAuth')
   Map<String, bool>? oauth;
 
   UserResponse(this.userId, this.loginIds, this.name, this.picture, this.email, this.verifiedEmail, this.phone, this.verifiedPhone, this.createdTime, this.customAttributes, this.givenName, this.middleName, this.familyName, this.password, this.status, this.roleNames, this.ssoAppIds, this.oauth);

--- a/lib/src/internal/http/responses.g.dart
+++ b/lib/src/internal/http/responses.g.dart
@@ -15,6 +15,7 @@ JWTServerResponse _$JWTServerResponseFromJson(Map<String, dynamic> json) =>
           : UserResponse.fromJson(json['user'] as Map<String, dynamic>),
       json['firstSeen'] as bool,
       json['externalToken'] as String?,
+      json['flowOutput'] as Map<String, dynamic>?,
     );
 
 UserResponse _$UserResponseFromJson(Map<String, dynamic> json) => UserResponse(

--- a/lib/src/internal/routes/shared.dart
+++ b/lib/src/internal/routes/shared.dart
@@ -69,7 +69,7 @@ extension ConvertJWTResponse on JWTServerResponse {
       throw InternalErrors.decodeError.add(message: 'Missing user details');
     }
 
-    return AuthenticationResponse(sessionToken, refreshToken, firstSeen, user.convert(), externalToken);
+    return AuthenticationResponse(sessionToken, refreshToken, firstSeen, user.convert(), externalToken, flowOutput ?? const {});
   }
 
   RefreshResponse toRefreshResponse() {

--- a/lib/src/types/responses.dart
+++ b/lib/src/types/responses.dart
@@ -20,7 +20,12 @@ class AuthenticationResponse {
   /// A value for an external token if the authentication returns it.
   final String? externalToken;
 
-  AuthenticationResponse(this.sessionToken, this.refreshToken, this.isFirstAuthentication, this.user, this.externalToken);
+  /// Custom data returned from a flow's output, when running a flow that sets it.
+  ///
+  /// This is always empty for non-flow authentications.
+  final Map<String, dynamic> flowOutput;
+
+  AuthenticationResponse(this.sessionToken, this.refreshToken, this.isFirstAuthentication, this.user, this.externalToken, this.flowOutput);
 }
 
 /// Returned from the refreshSession call.

--- a/test/responses_test.dart
+++ b/test/responses_test.dart
@@ -1,0 +1,42 @@
+import 'package:descope/src/internal/http/responses.dart';
+import 'package:descope/src/internal/routes/shared.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikdvb2dseSBNY0ZsdXR0ZXIiLCJpYXQiOjE1MTYyMzkwMjIsImlzcyI6Imh0dHBzOi8vZGVzY29wZS5jb20vYmxhL1AxMjMiLCJleHAiOjE2MDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.MuAWVKcw4xLNTvgTa-1lilcTcu8bd7sNV7xS55LD55M';
+
+Map<String, dynamic> _payload({Map<String, dynamic>? flowOutput}) => {
+      'sessionJwt': _jwt,
+      'refreshJwt': _jwt,
+      'firstSeen': true,
+      'user': {
+        'userId': 'userId',
+        'loginIds': ['loginId'],
+        'verifiedEmail': true,
+        'verifiedPhone': false,
+        'createdTime': 1234567890,
+        'password': false,
+        'status': 'enabled',
+        'roleNames': <String>[],
+        'ssoAppIds': <String>[],
+      },
+      if (flowOutput != null) 'flowOutput': flowOutput,
+    };
+
+void main() {
+  test('flow output is parsed when present', () {
+    final response = JWTServerResponse.fromJson(_payload(flowOutput: {
+      'key': 'value',
+      'count': 3,
+      'nested': {'inner': true},
+    })).toAuthenticationResponse();
+
+    expect(response.flowOutput['key'], 'value');
+    expect(response.flowOutput['count'], 3);
+    expect((response.flowOutput['nested'] as Map)['inner'], true);
+  });
+
+  test('flow output is empty when missing', () {
+    final response = JWTServerResponse.fromJson(_payload()).toAuthenticationResponse();
+    expect(response.flowOutput, isEmpty);
+  });
+}


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16932

## Description
- Expose `flowOutput` on `AuthenticationResponse`, populated from a flow's output
- Pipe the value through the native bridges on Android and iOS
- Update the native SDKs to descope-kotlin `0.20.0` and descope-swift `0.11.2`

## Must
- [x] Tests
- [x] Documentation